### PR TITLE
SOC-492 adding skeleton for web components code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.gem
 *.rbc
 *.swp
+*/Gemfile.lock
 .idea
 /.config
 /coverage/

--- a/dist/scripts/components/example.js
+++ b/dist/scripts/components/example.js
@@ -1,0 +1,1 @@
+// JS for example web component goes here

--- a/dist/templates/example.html
+++ b/dist/templates/example.html
@@ -1,0 +1,3 @@
+<template id="exampleTemplate">
+  <!-- html for example web component goes here -->
+</template>

--- a/gh-pages/_includes/head.html
+++ b/gh-pages/_includes/head.html
@@ -1,13 +1,15 @@
 <head>
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width initial-scale=1" />
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+	<meta charset="utf-8">
+	<meta name="viewport" content="width=device-width initial-scale=1" />
+	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 
-    <title>{% if page.title %}{{ page.title }}{% else %}{{ site.title }}{% endif %}</title>
-    <meta name="description" content="{{ site.description }}">
+	<title>{% if page.title %}{{ page.title }}{% else %}{{ site.title }}{% endif %}</title>
+	<meta name="description" content="{{ site.description }}">
 
-    <link rel="shortcut icon" href="{{ site.baseurl }}/favicon.ico">
-    <link rel="stylesheet" href="{{ "/vendor/wikia-style-guide/dist/css/main.css" | prepend: site.baseurl }}">
-    <link rel="stylesheet" href="{{ "/css/main.css" | prepend: site.baseurl }}">
-    <link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url }}">
+	<link rel="shortcut icon" href="{{ site.baseurl }}/favicon.ico">
+	<link rel="stylesheet" href="{{ "/vendor/wikia-style-guide/dist/css/main.css" | prepend: site.baseurl }}">
+	<link rel="stylesheet" href="{{ "/css/main.css" | prepend: site.baseurl }}">
+	<link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url }}">
+
+	<script src="{{ "/vendor/wikia-style-guide/dist/vendor/webcomponentsjs/webcomponents-lite.min.js" | prepend: site.baseurl }}"></script>
 </head>

--- a/gh-pages/vendor/wikia-style-guide/dist/scripts/components/example.js
+++ b/gh-pages/vendor/wikia-style-guide/dist/scripts/components/example.js
@@ -1,0 +1,1 @@
+// JS for example web component goes here

--- a/gh-pages/vendor/wikia-style-guide/dist/templates/example.html
+++ b/gh-pages/vendor/wikia-style-guide/dist/templates/example.html
@@ -1,0 +1,3 @@
+<template id="exampleTemplate">
+  <!-- html for example web component goes here -->
+</template>

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -16,6 +16,21 @@ gulp.task('svg:icons', function () {
 		.pipe(gulp.dest('./dist/icons'));
 });
 
+gulp.task('vendor', function () {
+	return gulp.src('./src/vendor/**/*')
+		.pipe(gulp.dest('./dist/vendor'));
+});
+
+gulp.task('scripts', function () {
+	return gulp.src('./src/scripts/**/*.js')
+		.pipe(gulp.dest('./dist/scripts'));
+});
+
+gulp.task('templates', function () {
+	return gulp.src('./src/templates/*.html')
+		.pipe(gulp.dest('./dist/templates'));
+});
+
 gulp.task('svg:images', function () {
 	return gulp.src('./src/svg/*.svg')
 		.pipe(gulp.dest('./dist/svg'));
@@ -29,7 +44,16 @@ gulp.task('dist:clean', function () {
 	return del.sync('./dist/**');
 });
 
-gulp.task('update-static', ['dist:clean', 'static:clean', 'svg:icons', 'svg:images', 'sass'], function () {
+gulp.task('update-static', [
+	'dist:clean',
+	'static:clean',
+	'svg:icons',
+	'svg:images',
+	'sass',
+	'vendor',
+	'scripts',
+	'templates'
+], function () {
 	return gulp.src('./dist/**/*')
 		.pipe(gulp.dest('./gh-pages/vendor/wikia-style-guide/dist'));
 });

--- a/src/scripts/components/example.js
+++ b/src/scripts/components/example.js
@@ -1,0 +1,1 @@
+// JS for example web component goes here

--- a/src/templates/example.html
+++ b/src/templates/example.html
@@ -1,0 +1,3 @@
+<template id="exampleTemplate">
+  <!-- html for example web component goes here -->
+</template>


### PR DESCRIPTION
Taking the skeleton from https://github.com/Wikia/style-guide/pull/42/files and merging just the parts we feel safe to merge. 

This PR sets up the folder directory and gulp tasks needed for supporting web components in the style guide. 

@kenkouot @bkoval 
