### PR TITLE
Hg 837 Adding user status drop-down to style guide top-bar component

### DIFF
--- a/dist/components/top-bar/top-bar.html
+++ b/dist/components/top-bar/top-bar.html
@@ -38,84 +38,6 @@ registration/signin callout is shown or whether the user avatar is shown.
 				fill: #092344;
 				width: 82px;
 			}
-
-			.user-status {
-				float: right;
-			}
-
-			.user-status figure {
-				margin-top: 3px;
-				width: 36px;
-				height: 36px;
-				border-radius: 50%;
-				overflow: hidden;
-			}
-
-			.user-status figure img {
-				width: 100%;
-				height: auto;
-			}
-
-			.register-cta {
-				margin-top: 10px;
-			}
-
-			.overlay {
-				/*@include perfect-square(100%);*/
-				background-color: black;
-				left: 0;
-				position: fixed;
-				top: 0;
-				z-index: 1000; /* TODO - firgure out number from mercury app */
-			}
-
-			.drawer {
-				list-style: none;
-				overflow: hidden;
-				position: fixed;
-				right: 0;
-				top: 0;
-				transition: height .1s;
-				width: 100%;
-				z-index: 1000; /* TODO - firgure out number from mercury app */
-			}
-
-			.drawer a {
-				/*@extend .touch-active;*/
-				display: block;
-				overflow: hidden;
-				padding: 0.625rem 0.8125rem; /* TODO - this is done with rem-calc in mercury */
-				text-overflow: ellipsis;
-				width: 100%;
-			}
-
-			.drawer ::content li {
-				background-color: #fff;
-				border-bottom: 0.0625rem solid #d0d0d0;
-			}
-
-			.collapsed .drawer {
-				height: 0;
-			}
-
-			.collapsed .overlay {
-				opacity: 0;
-				transition: visibility 0s 0.1s, opacity 0.1s; /* TODO - mercury uses variables for these values */
-				visibility: hidden;
-			}
-
-			.visible .drawer {
-				/* This is an arbitrary number larger than the combined height of the
-				li children, so that transition animation works. With height: auto,
-				it wouldn't be guaranteed to work. */
-				height: 100px;
-			}
-
-			.visible .overlay {
-				opacity: 0.5; /* TODO - mercury uses variables for these values */
-				transition: opacity 0.1s; /* TODO - mercury uses variables for these values */
-				visibility: visible;
-			}
 		</style>
 
 		<div class="row">
@@ -123,29 +45,7 @@ registration/signin callout is shown or whether the user avatar is shown.
 				<a href="{{logoHref}}"><img src="{{logoSrc}}" alt="Wikia" class="logo left"></a>
 
 				<!-- Catch all for transcluded content -->
-				<content select=".default-content"></content>
-
-				<template is="dom-if" if="{{showUserStatus}}">
-					<div class="user-status visible">
-						<template is="dom-if" if="{{userLoggedIn}}">
-							<a href="{{userAvatarHref}}">
-								<figure>
-									<img src="{{userAvatarSrc}}" alt="{{userName}}">
-								</figure>
-							</a>
-							<div class="overlay"></div>
-							<ul class="drawer">
-								<content select=".drawer-li"></content>
-							</ul>
-						</template>
-
-						<template is="dom-if" if="{{!userLoggedIn}}">
-							<div class="register-cta">
-								<a href="#">Register</a> or <a href="#">Login</a>
-							</div>
-						</template>
-					</div>
-				</template>
+				<content></content>
 			</div>
 		</div>
 	</template>
@@ -156,16 +56,8 @@ registration/signin callout is shown or whether the user avatar is shown.
 		Polymer({
 			is: 'top-bar',
 			properties: {
-				userAvatarSrc: String,
-				userProfileHref: String,
-				userName: String,
 				logoHref: String,
 				logoSrc: String,
-				userLoggedIn: {
-					type: Boolean,
-					value: false,
-					reflectToAttribute: true
-				},
 				showUserStatus: {
 					type: Boolean,
 					value: false

--- a/dist/components/top-bar/top-bar.html
+++ b/dist/components/top-bar/top-bar.html
@@ -58,6 +58,63 @@ registration/signin callout is shown or whether the user avatar is shown.
 		.register-cta {
 			margin-top: 10px;
 		}
+
+		.overlay {
+			/*@include perfect-square(100%);*/
+			background-color: black;
+			left: 0;
+			position: fixed;
+			top: 0;
+			z-index: 1000; /* TODO - firgure out number from mercury app */
+		}
+
+		.drawer {
+			list-style: none;
+			overflow: hidden;
+			position: fixed;
+			right: 0;
+			top: 0;
+			transition: height .1s;
+			width: 100%;
+			z-index: 1000; /* TODO - firgure out number from mercury app */
+		}
+
+		.drawer a {
+			/*@extend .touch-active;*/
+			display: block;
+			overflow: hidden;
+			padding: 0.625rem 0.8125rem; /* TODO - this is done with rem-calc in mercury */
+			text-overflow: ellipsis;
+			width: 100%;
+		}
+
+		li {
+			background-color: #fff;
+			border-bottom: rem-calc(1) solid #d0d0d0;
+		}
+
+		.collapsed .drawer {
+			height: 0;
+		}
+
+		.collapsed .overlay {
+			opacity: 0;
+			transition: visibility 0s 0.1s, opacity 0.1s; /* TODO - mercury uses variables for these values */
+			visibility: hidden;
+		}
+
+		.visible .drawer {
+			/* This is an arbitrary number larger than the combined height of the
+			li children, so that transition animation works. With height: auto,
+			it wouldn't be guaranteed to work. */
+			height: 100px;
+		}
+
+		.visible .overlay {
+			opacity: 0.5; /* TODO - mercury uses variables for these values */
+			transition: opacity 0.1s; /* TODO - mercury uses variables for these values */
+			visibility: visible;
+		}
 	</style>
 
 	<template>
@@ -69,25 +126,26 @@ registration/signin callout is shown or whether the user avatar is shown.
 				<content select=".content"></content>
 
 				<template is="dom-if" if="{{showUserStatus}}">
-					<div class="user-status">
+					<div class="user-status collapsed">
 						<template is="dom-if" if="{{userLoggedIn}}">
 							<a href="{{userAvatarHref}}">
-									<figure>
-										<img src="{{userAvatarSrc}}" alt="{{userName}}">
+								<figure>
+									<img src="{{userAvatarSrc}}" alt="{{userName}}">
 								</figure>
 							</a>
 							<div class="overlay"></div>
-							<content select=".drawer"></content>
+							<ul class="drawer">
+								<content select=".drawer-li"></content>
+							</ul>
 						</template>
 
 						<template is="dom-if" if="{{!userLoggedIn}}">
-								<div class="register-cta">
-									<a href="#">Register</a> or <a href="#">Login</a>
-								</div>
+							<div class="register-cta">
+								<a href="#">Register</a> or <a href="#">Login</a>
+							</div>
 						</template>
 					</div>
 				</template>
-
 			</div>
 		</div>
 	</template>

--- a/dist/components/top-bar/top-bar.html
+++ b/dist/components/top-bar/top-bar.html
@@ -18,115 +18,115 @@ shown or not. If `showUserStatus` is true, then the `userLoggedIn` attribute wil
 registration/signin callout is shown or whether the user avatar is shown.
 -->
 <dom-module id="top-bar">
-	<style>
-		[unresolved] {
-			visibility: hidden;
-		}
-
-		:host {
-			display: block;
-			background-color: #fff;
-			border-bottom: 1px solid #ccc;
-			height: 46px;
-			position: fixed;
-			width: 100%;
-			z-index: 9999999;
-		}
-
-		.logo {
-			fill: #092344;
-			width: 82px;
-		}
-
-		.user-status {
-			float: right;
-		}
-
-		.user-status figure {
-			margin-top: 3px;
-			width: 36px;
-			height: 36px;
-			border-radius: 50%;
-			overflow: hidden;
-		}
-
-		.user-status figure img {
-			width: 100%;
-			height: auto;
-		}
-
-		.register-cta {
-			margin-top: 10px;
-		}
-
-		.overlay {
-			/*@include perfect-square(100%);*/
-			background-color: black;
-			left: 0;
-			position: fixed;
-			top: 0;
-			z-index: 1000; /* TODO - firgure out number from mercury app */
-		}
-
-		.drawer {
-			list-style: none;
-			overflow: hidden;
-			position: fixed;
-			right: 0;
-			top: 0;
-			transition: height .1s;
-			width: 100%;
-			z-index: 1000; /* TODO - firgure out number from mercury app */
-		}
-
-		.drawer a {
-			/*@extend .touch-active;*/
-			display: block;
-			overflow: hidden;
-			padding: 0.625rem 0.8125rem; /* TODO - this is done with rem-calc in mercury */
-			text-overflow: ellipsis;
-			width: 100%;
-		}
-
-		li {
-			background-color: #fff;
-			border-bottom: rem-calc(1) solid #d0d0d0;
-		}
-
-		.collapsed .drawer {
-			height: 0;
-		}
-
-		.collapsed .overlay {
-			opacity: 0;
-			transition: visibility 0s 0.1s, opacity 0.1s; /* TODO - mercury uses variables for these values */
-			visibility: hidden;
-		}
-
-		.visible .drawer {
-			/* This is an arbitrary number larger than the combined height of the
-			li children, so that transition animation works. With height: auto,
-			it wouldn't be guaranteed to work. */
-			height: 100px;
-		}
-
-		.visible .overlay {
-			opacity: 0.5; /* TODO - mercury uses variables for these values */
-			transition: opacity 0.1s; /* TODO - mercury uses variables for these values */
-			visibility: visible;
-		}
-	</style>
-
 	<template>
+		<style>
+			[unresolved] {
+				visibility: hidden;
+			}
+
+			:host {
+				display: block;
+				background-color: #fff;
+				border-bottom: 1px solid #ccc;
+				height: 46px;
+				position: fixed;
+				width: 100%;
+				z-index: 9999999;
+			}
+
+			.logo {
+				fill: #092344;
+				width: 82px;
+			}
+
+			.user-status {
+				float: right;
+			}
+
+			.user-status figure {
+				margin-top: 3px;
+				width: 36px;
+				height: 36px;
+				border-radius: 50%;
+				overflow: hidden;
+			}
+
+			.user-status figure img {
+				width: 100%;
+				height: auto;
+			}
+
+			.register-cta {
+				margin-top: 10px;
+			}
+
+			.overlay {
+				/*@include perfect-square(100%);*/
+				background-color: black;
+				left: 0;
+				position: fixed;
+				top: 0;
+				z-index: 1000; /* TODO - firgure out number from mercury app */
+			}
+
+			.drawer {
+				list-style: none;
+				overflow: hidden;
+				position: fixed;
+				right: 0;
+				top: 0;
+				transition: height .1s;
+				width: 100%;
+				z-index: 1000; /* TODO - firgure out number from mercury app */
+			}
+
+			.drawer a {
+				/*@extend .touch-active;*/
+				display: block;
+				overflow: hidden;
+				padding: 0.625rem 0.8125rem; /* TODO - this is done with rem-calc in mercury */
+				text-overflow: ellipsis;
+				width: 100%;
+			}
+
+			.drawer ::content li {
+				background-color: #fff;
+				border-bottom: 0.0625rem solid #d0d0d0;
+			}
+
+			.collapsed .drawer {
+				height: 0;
+			}
+
+			.collapsed .overlay {
+				opacity: 0;
+				transition: visibility 0s 0.1s, opacity 0.1s; /* TODO - mercury uses variables for these values */
+				visibility: hidden;
+			}
+
+			.visible .drawer {
+				/* This is an arbitrary number larger than the combined height of the
+				li children, so that transition animation works. With height: auto,
+				it wouldn't be guaranteed to work. */
+				height: 100px;
+			}
+
+			.visible .overlay {
+				opacity: 0.5; /* TODO - mercury uses variables for these values */
+				transition: opacity 0.1s; /* TODO - mercury uses variables for these values */
+				visibility: visible;
+			}
+		</style>
+
 		<div class="row">
 			<div class="large-12 columns">
 				<a href="{{logoHref}}"><img src="{{logoSrc}}" alt="Wikia" class="logo left"></a>
 
 				<!-- Catch all for transcluded content -->
-				<content select=".content"></content>
+				<content select=".default-content"></content>
 
 				<template is="dom-if" if="{{showUserStatus}}">
-					<div class="user-status collapsed">
+					<div class="user-status visible">
 						<template is="dom-if" if="{{userLoggedIn}}">
 							<a href="{{userAvatarHref}}">
 								<figure>

--- a/dist/components/top-bar/top-bar.html
+++ b/dist/components/top-bar/top-bar.html
@@ -25,9 +25,9 @@ registration/signin callout is shown or whether the user avatar is shown.
 			}
 
 			:host {
-				display: block;
 				background-color: #fff;
 				border-bottom: 1px solid #ccc;
+				display: block;
 				height: 46px;
 				position: fixed;
 				width: 100%;

--- a/dist/components/top-bar/top-bar.html
+++ b/dist/components/top-bar/top-bar.html
@@ -66,7 +66,7 @@ registration/signin callout is shown or whether the user avatar is shown.
 				<a href="{{logoHref}}"><img src="{{logoSrc}}" alt="Wikia" class="logo left"></a>
 
 				<!-- Catch all for transcluded content -->
-				<content></content>
+				<content select=".content"></content>
 
 				<template is="dom-if" if="{{showUserStatus}}">
 					<div class="user-status">
@@ -76,6 +76,8 @@ registration/signin callout is shown or whether the user avatar is shown.
 										<img src="{{userAvatarSrc}}" alt="{{userName}}">
 								</figure>
 							</a>
+							<div class="overlay"></div>
+							<content select=".drawer"></content>
 						</template>
 
 						<template is="dom-if" if="{{!userLoggedIn}}">

--- a/dist/components/user-status/user-status.html
+++ b/dist/components/user-status/user-status.html
@@ -1,0 +1,124 @@
+<dom-module id="user-status">
+	<template>
+		<style>
+			:host {
+				float: right;
+			}
+
+			figure {
+				border-radius: 50%;
+				height: 28px;
+				margin-top: 7px;
+				overflow: hidden;
+				width: 28px;
+			}
+
+			figure img {
+				height: auto;
+				width: 100%;
+			}
+
+			.register-cta {
+				margin-top: 10px;
+			}
+
+			.overlay {
+				/*@include perfect-square(100%);*/ /* TODO - uncomment and fix */
+				background-color: black;
+				left: 0;
+				position: fixed;
+				top: 0;
+				z-index: 1000;
+			}
+
+			.drawer {
+				list-style: none;
+				overflow: hidden;
+				position: fixed;
+				right: 0;
+				top: 0;
+				transition: height .1s;
+				width: 100%;
+				z-index: 1000;
+			}
+
+			.drawer a {
+				/*@extend .touch-active;*/  /* TODO - uncomment and fix */
+				display: block;
+				overflow: hidden;
+				padding: 0.625rem 0.8125rem;
+				text-overflow: ellipsis;
+				width: 100%;
+			}
+
+			.drawer ::content li {
+				background-color: #fff;
+				border-bottom: 0.0625rem solid #d0d0d0;
+			}
+
+			.drawer {
+				height: 0;
+			}
+
+			.overlay {
+				opacity: 0;
+				transition: visibility 0s 0.1s, opacity 0.1s;
+				visibility: hidden;
+			}
+
+			:host.visible .drawer {
+				/* This is an arbitrary number larger than the combined height of the
+				li children, so that transition animation works. With height: auto,
+				it wouldn't be guaranteed to work. */
+				height: 100px;
+			}
+
+			:host.visible .overlay {
+				opacity: 0.5;
+				transition: opacity 0.1s;
+				visibility: visible;
+			}
+		</style>
+
+		<template is="dom-if" if="{{userLoggedIn}}">
+			<a href="{{userAvatarHref}}">
+				<figure>
+					<img src="{{userAvatarSrc}}" alt="{{userName}}">
+				</figure>
+			</a>
+			<div class="overlay"></div>
+			<ul class="drawer">
+				<content select=".drawer-li"></content>
+			</ul>
+		</template>
+
+		<template is="dom-if" if="{{!userLoggedIn}}">
+			<div class="register-cta">
+				<span class="show-for-large-up"><a href="#">Register</a> or <a href="#">Login</a></span>
+				<figure class="hide-for-large-up">
+					<img src="{{anonAvatarSrc}}" alt="Register or login">
+				</figure>
+			</div>
+		</template>
+	</template>
+
+</dom-module>
+
+<script>
+	(function () {
+		Polymer({
+			is: 'user-status',
+			properties: {
+				userAvatarHref: String,
+				userAvatarSrc: String,
+				userName: String,
+				anonAvatarSrc: String,
+				userLoggedIn: {
+					type: Boolean,
+					value: false,
+					reflectToAttribute: true
+				}
+			}
+		});
+	}());
+</script>

--- a/dist/components/user-status/user-status.html
+++ b/dist/components/user-status/user-status.html
@@ -77,9 +77,6 @@
 					top: 46px;
 					width: 150px;
 				}
-
-				:host.visible .drawer {
-				}
 			}
 
 			.overlay {

--- a/dist/components/user-status/user-status.html
+++ b/dist/components/user-status/user-status.html
@@ -50,13 +50,18 @@
 				max-height: 600px;
 			}
 
-			.drawer a {
-				/*@extend .touch-active;*/  /* TODO - uncomment and fix */
+			.drawer ::content a {
 				display: block;
+				height: auto;
+				line-height: normal;
 				overflow: hidden;
 				padding: 0.625rem 0.8125rem;
 				text-overflow: ellipsis;
 				width: 100%;
+			}
+
+			.drawer ::content a:active {
+				background-color: #F2F6FA;
 			}
 
 			.drawer ::content li {

--- a/dist/components/user-status/user-status.html
+++ b/dist/components/user-status/user-status.html
@@ -121,10 +121,10 @@
 
 		<template is="dom-if" if="{{!userLoggedIn}}">
 			<div class="register-cta">
-				<span class="show-for-large-up"><a href="#">Register</a> or <a href="#">Login</a></span>
+				<span class="show-for-large-up"><a href="#">Register</a> or <a href="#">Log in</a></span>
 				<figure class="hide-for-large-up">
 					<a href="{{anonAvatarHref}}">
-						<img src="{{anonAvatarSrc}}" alt="Register or login">
+						<img src="{{anonAvatarSrc}}" alt="Register or log in">
 					</a>
 				</figure>
 			</div>

--- a/dist/components/user-status/user-status.html
+++ b/dist/components/user-status/user-status.html
@@ -13,6 +13,10 @@
 				width: 28px;
 			}
 
+			figure a {
+				display: block;
+			}
+
 			figure img {
 				height: auto;
 				width: 100%;
@@ -20,6 +24,10 @@
 
 			.register-cta {
 				margin-top: 10px;
+			}
+
+			.logged-in-wrapper {
+				cursor: pointer;
 			}
 
 			.overlay {
@@ -61,9 +69,16 @@
 			}
 
 			.overlay {
+				background-color: black;
+				height: 100%;
+				left: 0;
 				opacity: 0;
+				position: fixed;
+				top: 0;
 				transition: visibility 0s 0.1s, opacity 0.1s;
 				visibility: hidden;
+				width: 100%;
+				z-index: 800;
 			}
 
 			:host.visible .drawer {
@@ -81,22 +96,24 @@
 		</style>
 
 		<template is="dom-if" if="{{userLoggedIn}}">
-			<a href="{{userAvatarHref}}">
-				<figure>
+			<div class="logged-in-wrapper">
+				<figure id="special" on-click="toggleDropdown">
 					<img src="{{userAvatarSrc}}" alt="{{userName}}">
 				</figure>
-			</a>
-			<div class="overlay"></div>
-			<ul class="drawer">
-				<content select=".drawer-li"></content>
-			</ul>
+				<div class="overlay" on-click="toggleDropdown"></div>
+				<ul class="drawer">
+					<content></content>
+				</ul>
+			</div>
 		</template>
 
 		<template is="dom-if" if="{{!userLoggedIn}}">
 			<div class="register-cta">
 				<span class="show-for-large-up"><a href="#">Register</a> or <a href="#">Login</a></span>
 				<figure class="hide-for-large-up">
-					<img src="{{anonAvatarSrc}}" alt="Register or login">
+					<a href="{{anonAvatarHref}}">
+						<img src="{{anonAvatarSrc}}" alt="Register or login">
+					</a>
 				</figure>
 			</div>
 		</template>
@@ -109,15 +126,24 @@
 		Polymer({
 			is: 'user-status',
 			properties: {
-				userAvatarHref: String,
 				userAvatarSrc: String,
 				userName: String,
 				anonAvatarSrc: String,
+				anonAvatarHref: String,
 				userLoggedIn: {
 					type: Boolean,
 					value: false,
 					reflectToAttribute: true
+				},
+				collapsed: {
+					type: Boolean,
+					value: true,
+					reflectToAttribute: true
 				}
+			},
+			toggleDropdown: function () {
+				var isVisible = Array.prototype.indexOf.call(this.classList, 'visible') > -1;
+				this.toggleClass('visible', !isVisible);
 			}
 		});
 	}());

--- a/dist/components/user-status/user-status.html
+++ b/dist/components/user-status/user-status.html
@@ -93,6 +93,14 @@
 				transition: opacity 0.1s;
 				visibility: visible;
 			}
+
+			/* Don't black out the rest of the screen on larger devices */
+			@media only screen and (min-width: 40.063em) {
+				:host.visible .overlay {
+					opacity: 0;
+				}
+			}
+
 		</style>
 
 		<template is="dom-if" if="{{userLoggedIn}}">

--- a/dist/components/user-status/user-status.html
+++ b/dist/components/user-status/user-status.html
@@ -3,6 +3,7 @@
 		<style>
 			:host {
 				float: right;
+				position: relative;
 			}
 
 			figure {
@@ -30,24 +31,23 @@
 				cursor: pointer;
 			}
 
-			.overlay {
-				/*@include perfect-square(100%);*/ /* TODO - uncomment and fix */
-				background-color: black;
-				left: 0;
-				position: fixed;
-				top: 0;
-				z-index: 1000;
-			}
-
 			.drawer {
 				list-style: none;
+				max-height: 0;
 				overflow: hidden;
 				position: fixed;
 				right: 0;
 				top: 0;
-				transition: height .1s;
+				transition: max-height .3s;
 				width: 100%;
 				z-index: 1000;
+			}
+
+			:host.visible .drawer {
+				/* This is an arbitrary number larger than the combined height of the
+				li children, so that transition animation works. With max-height: auto,
+				it wouldn't be guaranteed to work. */
+				max-height: 600px;
 			}
 
 			.drawer a {
@@ -61,11 +61,20 @@
 
 			.drawer ::content li {
 				background-color: #fff;
-				border-bottom: 0.0625rem solid #d0d0d0;
+				border: solid #d0d0d0;
+				border-width: 0 1px 1px 1px;
 			}
 
-			.drawer {
-				height: 0;
+			@media only screen and (min-width: 40.063em) {
+				.drawer {
+					position: absolute;
+					right: 0;
+					top: 46px;
+					width: 150px;
+				}
+
+				:host.visible .drawer {
+				}
 			}
 
 			.overlay {
@@ -75,22 +84,15 @@
 				opacity: 0;
 				position: fixed;
 				top: 0;
-				transition: visibility 0s 0.1s, opacity 0.1s;
+				transition: visibility 0s 0.3s, opacity 0.3s;
 				visibility: hidden;
 				width: 100%;
 				z-index: 800;
 			}
 
-			:host.visible .drawer {
-				/* This is an arbitrary number larger than the combined height of the
-				li children, so that transition animation works. With height: auto,
-				it wouldn't be guaranteed to work. */
-				height: 100px;
-			}
-
 			:host.visible .overlay {
 				opacity: 0.5;
-				transition: opacity 0.1s;
+				transition: opacity 0.3s;
 				visibility: visible;
 			}
 

--- a/gh-pages/_includes/global-nav.html
+++ b/gh-pages/_includes/global-nav.html
@@ -1,10 +1,7 @@
 <top-bar
 	class="global-navigation"
 	logo-src="{{ site.assets_path | prepend: site.baseurl }}/images/wikia_logo.svg"
-	logo-href="{{site.baseurl}}/"
-	user-avatar-src="http://img4.wikia.nocookie.net/__cb1372467243/common/avatars/thumb/e/eb/11096997.png/100px-11096997.png.jpg"
-	show-user-status="true"
-	user-logged-in="true">
+	logo-href="{{site.baseurl}}/">
 	<a class="menu-icon dropdown-icon left default-content">
 		<img src="{{ site.assets_path | prepend: site.baseurl }}/images/icons/icon_nav.svg">
 	</a>
@@ -32,8 +29,18 @@
 		</li>
 	</ul>
 
-	<li class="drawer-li"><a href="">foo</a></li>
-	<li class="drawer-li"><a href="">bar</a></li>
+	<user-status
+		class="visible"
+		user-avatar-src="http://img4.wikia.nocookie.net/__cb1372467243/common/avatars/thumb/e/eb/11096997.png/100px-11096997.png.jpg"
+		anon-avatar-src="{{ site.assets_path | prepend: site.baseurl }}/images/icons/icon_avatar.svg"
+		show-user-status
+		user-logged-in>
+		<li class="drawer-li"><a href="">foo</a></li>
+		<li class="drawer-li"><a href="">bar</a></li>
+	</user-status>
 
 	<a href="{{site.baseurl}}/" class="title left">Style Guide</a>
 </top-bar>
+
+
+

--- a/gh-pages/_includes/global-nav.html
+++ b/gh-pages/_includes/global-nav.html
@@ -1,33 +1,41 @@
 <top-bar
-  class="global-navigation"
-  logo-src="{{ site.assets_path | prepend: site.baseurl }}/images/wikia_logo.svg"
-  logo-href="{{site.baseurl}}/"
-  user-avatar-src="http://img4.wikia.nocookie.net/__cb1372467243/common/avatars/thumb/e/eb/11096997.png/100px-11096997.png.jpg">
-	<a class="menu-icon dropdown-icon left">
-		<img src="{{ site.assets_path | prepend: site.baseurl }}/images/icons/icon_nav.svg">
-	</a>
-	<ul class="f-dropdown" data-offset-x="-13" data-offset-y="13">
-		<li>
-			<a href="{{site.baseurl}}/">Home</a>
-		</li>
-		<li>
-			<a href="{{site.baseurl}}/section/colors">Colors</a>
-		</li>
-		<li>
-			<a href="{{site.baseurl}}/section/typography">Typography</a>
-		</li>
-		<li>
-			<a href="{{site.baseurl}}/section/buttons">Buttons</a>
-		</li>
-		<li>
-			<a href="{{site.baseurl}}/section/forms">Forms &amp; Dropdowns</a>
-		</li>
-		<li>
-			<a href="{{site.baseurl}}/section/imagery">Imagery</a>
-		</li>
-		<li>
-			<a href="{{site.baseurl}}/section/video">Video</a>
-		</li>
+	class="global-navigation"
+	logo-src="{{ site.assets_path | prepend: site.baseurl }}/images/wikia_logo.svg"
+	logo-href="{{site.baseurl}}/"
+	user-avatar-src="http://img4.wikia.nocookie.net/__cb1372467243/common/avatars/thumb/e/eb/11096997.png/100px-11096997.png.jpg"
+	show-user-status="true"
+	user-logged-in="true">
+	<div class="content">
+		<a class="menu-icon dropdown-icon left">
+			<img src="{{ site.assets_path | prepend: site.baseurl }}/images/icons/icon_nav.svg">
+		</a>
+		<ul class="f-dropdown" data-offset-x="-13" data-offset-y="13">
+			<li>
+				<a href="{{site.baseurl}}/">Home</a>
+			</li>
+			<li>
+				<a href="{{site.baseurl}}/section/colors">Colors</a>
+			</li>
+			<li>
+				<a href="{{site.baseurl}}/section/typography">Typography</a>
+			</li>
+			<li>
+				<a href="{{site.baseurl}}/section/buttons">Buttons</a>
+			</li>
+			<li>
+				<a href="{{site.baseurl}}/section/forms">Forms &amp; Dropdowns</a>
+			</li>
+			<li>
+				<a href="{{site.baseurl}}/section/imagery">Imagery</a>
+			</li>
+			<li>
+				<a href="{{site.baseurl}}/section/video">Video</a>
+			</li>
+		</ul>
+	</div>
+	<ul class="drawer">
+		<li>foo</li>
+		<li>bar</li>
 	</ul>
 
 	<a href="{{site.baseurl}}/" class="title left">Style Guide</a>

--- a/gh-pages/_includes/global-nav.html
+++ b/gh-pages/_includes/global-nav.html
@@ -30,13 +30,12 @@
 	</ul>
 
 	<user-status
-		class="visible"
 		user-avatar-src="http://img4.wikia.nocookie.net/__cb1372467243/common/avatars/thumb/e/eb/11096997.png/100px-11096997.png.jpg"
 		anon-avatar-src="{{ site.assets_path | prepend: site.baseurl }}/images/icons/icon_avatar.svg"
-		show-user-status
+		anon-avatar-href="https://www.wikia.com/join"
 		user-logged-in>
-		<li class="drawer-li"><a href="">foo</a></li>
-		<li class="drawer-li"><a href="">bar</a></li>
+		<li><a href="">foo</a></li>
+		<li><a href="">bar</a></li>
 	</user-status>
 
 	<a href="{{site.baseurl}}/" class="title left">Style Guide</a>

--- a/gh-pages/_includes/global-nav.html
+++ b/gh-pages/_includes/global-nav.html
@@ -5,10 +5,10 @@
 	user-avatar-src="http://img4.wikia.nocookie.net/__cb1372467243/common/avatars/thumb/e/eb/11096997.png/100px-11096997.png.jpg"
 	show-user-status="true"
 	user-logged-in="true">
-	<a class="menu-icon dropdown-icon left content">
+	<a class="menu-icon dropdown-icon left default-content">
 		<img src="{{ site.assets_path | prepend: site.baseurl }}/images/icons/icon_nav.svg">
 	</a>
-	<ul class="f-dropdown content" data-offset-x="-13" data-offset-y="13">
+	<ul class="f-dropdown default-content" data-offset-x="-13" data-offset-y="13">
 		<li>
 			<a href="{{site.baseurl}}/">Home</a>
 		</li>
@@ -32,8 +32,8 @@
 		</li>
 	</ul>
 
-	<li class="drawer-li">foo</li>
-	<li class="drawer-li">bar</li>
+	<li class="drawer-li"><a href="">foo</a></li>
+	<li class="drawer-li"><a href="">bar</a></li>
 
 	<a href="{{site.baseurl}}/" class="title left">Style Guide</a>
 </top-bar>

--- a/gh-pages/_includes/global-nav.html
+++ b/gh-pages/_includes/global-nav.html
@@ -5,38 +5,35 @@
 	user-avatar-src="http://img4.wikia.nocookie.net/__cb1372467243/common/avatars/thumb/e/eb/11096997.png/100px-11096997.png.jpg"
 	show-user-status="true"
 	user-logged-in="true">
-	<div class="content">
-		<a class="menu-icon dropdown-icon left">
-			<img src="{{ site.assets_path | prepend: site.baseurl }}/images/icons/icon_nav.svg">
-		</a>
-		<ul class="f-dropdown" data-offset-x="-13" data-offset-y="13">
-			<li>
-				<a href="{{site.baseurl}}/">Home</a>
-			</li>
-			<li>
-				<a href="{{site.baseurl}}/section/colors">Colors</a>
-			</li>
-			<li>
-				<a href="{{site.baseurl}}/section/typography">Typography</a>
-			</li>
-			<li>
-				<a href="{{site.baseurl}}/section/buttons">Buttons</a>
-			</li>
-			<li>
-				<a href="{{site.baseurl}}/section/forms">Forms &amp; Dropdowns</a>
-			</li>
-			<li>
-				<a href="{{site.baseurl}}/section/imagery">Imagery</a>
-			</li>
-			<li>
-				<a href="{{site.baseurl}}/section/video">Video</a>
-			</li>
-		</ul>
-	</div>
-	<ul class="drawer">
-		<li>foo</li>
-		<li>bar</li>
+	<a class="menu-icon dropdown-icon left content">
+		<img src="{{ site.assets_path | prepend: site.baseurl }}/images/icons/icon_nav.svg">
+	</a>
+	<ul class="f-dropdown content" data-offset-x="-13" data-offset-y="13">
+		<li>
+			<a href="{{site.baseurl}}/">Home</a>
+		</li>
+		<li>
+			<a href="{{site.baseurl}}/section/colors">Colors</a>
+		</li>
+		<li>
+			<a href="{{site.baseurl}}/section/typography">Typography</a>
+		</li>
+		<li>
+			<a href="{{site.baseurl}}/section/buttons">Buttons</a>
+		</li>
+		<li>
+			<a href="{{site.baseurl}}/section/forms">Forms &amp; Dropdowns</a>
+		</li>
+		<li>
+			<a href="{{site.baseurl}}/section/imagery">Imagery</a>
+		</li>
+		<li>
+			<a href="{{site.baseurl}}/section/video">Video</a>
+		</li>
 	</ul>
+
+	<li class="drawer-li">foo</li>
+	<li class="drawer-li">bar</li>
 
 	<a href="{{site.baseurl}}/" class="title left">Style Guide</a>
 </top-bar>

--- a/gh-pages/_includes/head.html
+++ b/gh-pages/_includes/head.html
@@ -14,4 +14,5 @@
 	<script src="{{ '/vendor/wikia-style-guide/dist/vendor/webcomponentsjs/webcomponents-lite.js' | prepend: site.baseurl }}"></script>
 	<link rel="import" href="{{ '/vendor/wikia-style-guide/dist/vendor/polymer/polymer.html' | prepend: site.baseurl }}">
 	<link rel="import" href="{{ '/vendor/wikia-style-guide/dist/components/top-bar/top-bar.html' | prepend: site.baseurl }}">
+	<link rel="import" href="{{ '/vendor/wikia-style-guide/dist/components/user-status/user-status.html' | prepend: site.baseurl }}">
 </head>

--- a/gh-pages/vendor/wikia-style-guide/dist/components/top-bar/top-bar.html
+++ b/gh-pages/vendor/wikia-style-guide/dist/components/top-bar/top-bar.html
@@ -7,110 +7,112 @@ This component provides a default top bar for Wikia websites and includes handli
 to action for anonymous users.
 
 Example:
-  <top-bar
-    user-avatar-src="foo.png" user-profile-href="http://wwww.wikia.com" user-name="Wikia User"
-    logo-href="http://www.wikia.com" logo-src="logo.svg" user-logged-in show-user-status>
-    <h1>Hello World!</h1>
-  </top-bar>
+	<top-bar
+		user-avatar-src="foo.png" user-profile-href="http://wwww.wikia.com" user-name="Wikia User"
+		logo-href="http://www.wikia.com" logo-src="logo.svg" user-logged-in show-user-status>
+		<h1>Hello World!</h1>
+	</top-bar>
 
 You can use the `showUserStatus` to control whether or not the callout for user registration/user logged in avatar is
 shown or not. If `showUserStatus` is true, then the `userLoggedIn` attribute will control whether or not the
 registration/signin callout is shown or whether the user avatar is shown.
 -->
 <dom-module id="top-bar">
-  <style>
-    [unresolved] {
-      visibility: hidden;
-    }
+	<style>
+		[unresolved] {
+			visibility: hidden;
+		}
 
-    :host {
-      display: block;
-      background-color: #fff;
-      border-bottom: 1px solid #ccc;
-      height: 46px;
-      position: fixed;
-      width: 100%;
-      z-index: 9999999;
-    }
+		:host {
+			display: block;
+			background-color: #fff;
+			border-bottom: 1px solid #ccc;
+			height: 46px;
+			position: fixed;
+			width: 100%;
+			z-index: 9999999;
+		}
 
-    .logo {
-      fill: #092344;
-      width: 82px;
-    }
+		.logo {
+			fill: #092344;
+			width: 82px;
+		}
 
-    .user-status {
-      float: right;
-    }
+		.user-status {
+			float: right;
+		}
 
-    .user-status figure {
-      margin-top: 3px;
-      width: 36px;
-      height: 36px;
-      border-radius: 50%;
-      overflow: hidden;
-    }
+		.user-status figure {
+			margin-top: 3px;
+			width: 36px;
+			height: 36px;
+			border-radius: 50%;
+			overflow: hidden;
+		}
 
-    .user-status figure img {
-      width: 100%;
-      height: auto;
-    }
+		.user-status figure img {
+			width: 100%;
+			height: auto;
+		}
 
-    .register-cta {
-      margin-top: 10px;
-    }
-  </style>
+		.register-cta {
+			margin-top: 10px;
+		}
+	</style>
 
-  <template>
-    <div class="row">
-      <div class="large-12 columns">
-        <a href="{{logoHref}}"><img src="{{logoSrc}}" alt="Wikia" class="logo left"></a>
+	<template>
+		<div class="row">
+			<div class="large-12 columns">
+				<a href="{{logoHref}}"><img src="{{logoSrc}}" alt="Wikia" class="logo left"></a>
 
-        <!-- Catch all for transcluded content -->
-        <content></content>
+				<!-- Catch all for transcluded content -->
+				<content select=".content"></content>
 
-        <template is="dom-if" if="{{showUserStatus}}">
-          <div class="user-status">
-            <template is="dom-if" if="{{userLoggedIn}}">
-              <a href="{{userAvatarHref}}">
-                  <figure>
-                    <img src="{{userAvatarSrc}}" alt="{{userName}}">
-                </figure>
-              </a>
-            </template>
+				<template is="dom-if" if="{{showUserStatus}}">
+					<div class="user-status">
+						<template is="dom-if" if="{{userLoggedIn}}">
+							<a href="{{userAvatarHref}}">
+									<figure>
+										<img src="{{userAvatarSrc}}" alt="{{userName}}">
+								</figure>
+							</a>
+							<div class="overlay"></div>
+							<content select=".drawer"></content>
+						</template>
 
-            <template is="dom-if" if="{{!userLoggedIn}}">
-                <div class="register-cta">
-                  <a href="#">Register</a> or <a href="#">Login</a>
-                </div>
-            </template>
-          </div>
-        </template>
+						<template is="dom-if" if="{{!userLoggedIn}}">
+								<div class="register-cta">
+									<a href="#">Register</a> or <a href="#">Login</a>
+								</div>
+						</template>
+					</div>
+				</template>
 
-      </div>
-    </div>
-  </template>
+			</div>
+		</div>
+	</template>
 </dom-module>
 
 <script>
-  (function () {
-    Polymer({
-      is: 'top-bar',
-      properties: {
-        userAvatarSrc: String,
-        userProfileHref: String,
-        userName: String,
-        logoHref: String,
-        logoSrc: String,
-        userLoggedIn: {
-          type: Boolean,
-          value: false,
-          reflectToAttribute: true
-        },
-        showUserStatus: {
-          type: Boolean,
-          value: false
-        }
-      }
-    });
-  }());
+	(function () {
+		Polymer({
+			is: 'top-bar',
+			properties: {
+				userAvatarSrc: String,
+				userProfileHref: String,
+				userName: String,
+				logoHref: String,
+				logoSrc: String,
+				userLoggedIn: {
+					type: Boolean,
+					value: false,
+					reflectToAttribute: true
+				},
+				showUserStatus: {
+					type: Boolean,
+					value: false
+				}
+			}
+		});
+	}());
 </script>

--- a/gh-pages/vendor/wikia-style-guide/dist/components/top-bar/top-bar.html
+++ b/gh-pages/vendor/wikia-style-guide/dist/components/top-bar/top-bar.html
@@ -38,84 +38,6 @@ registration/signin callout is shown or whether the user avatar is shown.
 				fill: #092344;
 				width: 82px;
 			}
-
-			.user-status {
-				float: right;
-			}
-
-			.user-status figure {
-				margin-top: 3px;
-				width: 36px;
-				height: 36px;
-				border-radius: 50%;
-				overflow: hidden;
-			}
-
-			.user-status figure img {
-				width: 100%;
-				height: auto;
-			}
-
-			.register-cta {
-				margin-top: 10px;
-			}
-
-			.overlay {
-				/*@include perfect-square(100%);*/
-				background-color: black;
-				left: 0;
-				position: fixed;
-				top: 0;
-				z-index: 1000; /* TODO - firgure out number from mercury app */
-			}
-
-			.drawer {
-				list-style: none;
-				overflow: hidden;
-				position: fixed;
-				right: 0;
-				top: 0;
-				transition: height .1s;
-				width: 100%;
-				z-index: 1000; /* TODO - firgure out number from mercury app */
-			}
-
-			.drawer a {
-				/*@extend .touch-active;*/
-				display: block;
-				overflow: hidden;
-				padding: 0.625rem 0.8125rem; /* TODO - this is done with rem-calc in mercury */
-				text-overflow: ellipsis;
-				width: 100%;
-			}
-
-			.drawer ::content li {
-				background-color: #fff;
-				border-bottom: 0.0625rem solid #d0d0d0;
-			}
-
-			.collapsed .drawer {
-				height: 0;
-			}
-
-			.collapsed .overlay {
-				opacity: 0;
-				transition: visibility 0s 0.1s, opacity 0.1s; /* TODO - mercury uses variables for these values */
-				visibility: hidden;
-			}
-
-			.visible .drawer {
-				/* This is an arbitrary number larger than the combined height of the
-				li children, so that transition animation works. With height: auto,
-				it wouldn't be guaranteed to work. */
-				height: 100px;
-			}
-
-			.visible .overlay {
-				opacity: 0.5; /* TODO - mercury uses variables for these values */
-				transition: opacity 0.1s; /* TODO - mercury uses variables for these values */
-				visibility: visible;
-			}
 		</style>
 
 		<div class="row">
@@ -123,29 +45,7 @@ registration/signin callout is shown or whether the user avatar is shown.
 				<a href="{{logoHref}}"><img src="{{logoSrc}}" alt="Wikia" class="logo left"></a>
 
 				<!-- Catch all for transcluded content -->
-				<content select=".default-content"></content>
-
-				<template is="dom-if" if="{{showUserStatus}}">
-					<div class="user-status visible">
-						<template is="dom-if" if="{{userLoggedIn}}">
-							<a href="{{userAvatarHref}}">
-								<figure>
-									<img src="{{userAvatarSrc}}" alt="{{userName}}">
-								</figure>
-							</a>
-							<div class="overlay"></div>
-							<ul class="drawer">
-								<content select=".drawer-li"></content>
-							</ul>
-						</template>
-
-						<template is="dom-if" if="{{!userLoggedIn}}">
-							<div class="register-cta">
-								<a href="#">Register</a> or <a href="#">Login</a>
-							</div>
-						</template>
-					</div>
-				</template>
+				<content></content>
 			</div>
 		</div>
 	</template>
@@ -156,16 +56,8 @@ registration/signin callout is shown or whether the user avatar is shown.
 		Polymer({
 			is: 'top-bar',
 			properties: {
-				userAvatarSrc: String,
-				userProfileHref: String,
-				userName: String,
 				logoHref: String,
 				logoSrc: String,
-				userLoggedIn: {
-					type: Boolean,
-					value: false,
-					reflectToAttribute: true
-				},
 				showUserStatus: {
 					type: Boolean,
 					value: false

--- a/gh-pages/vendor/wikia-style-guide/dist/components/top-bar/top-bar.html
+++ b/gh-pages/vendor/wikia-style-guide/dist/components/top-bar/top-bar.html
@@ -58,6 +58,63 @@ registration/signin callout is shown or whether the user avatar is shown.
 		.register-cta {
 			margin-top: 10px;
 		}
+
+		.overlay {
+			/*@include perfect-square(100%);*/
+			background-color: black;
+			left: 0;
+			position: fixed;
+			top: 0;
+			z-index: 1000; /* TODO - firgure out number from mercury app */
+		}
+
+		.drawer {
+			list-style: none;
+			overflow: hidden;
+			position: fixed;
+			right: 0;
+			top: 0;
+			transition: height .1s;
+			width: 100%;
+			z-index: 1000; /* TODO - firgure out number from mercury app */
+		}
+
+		.drawer a {
+			/*@extend .touch-active;*/
+			display: block;
+			overflow: hidden;
+			padding: 0.625rem 0.8125rem; /* TODO - this is done with rem-calc in mercury */
+			text-overflow: ellipsis;
+			width: 100%;
+		}
+
+		li {
+			background-color: #fff;
+			border-bottom: rem-calc(1) solid #d0d0d0;
+		}
+
+		.collapsed .drawer {
+			height: 0;
+		}
+
+		.collapsed .overlay {
+			opacity: 0;
+			transition: visibility 0s 0.1s, opacity 0.1s; /* TODO - mercury uses variables for these values */
+			visibility: hidden;
+		}
+
+		.visible .drawer {
+			/* This is an arbitrary number larger than the combined height of the
+			li children, so that transition animation works. With height: auto,
+			it wouldn't be guaranteed to work. */
+			height: 100px;
+		}
+
+		.visible .overlay {
+			opacity: 0.5; /* TODO - mercury uses variables for these values */
+			transition: opacity 0.1s; /* TODO - mercury uses variables for these values */
+			visibility: visible;
+		}
 	</style>
 
 	<template>
@@ -69,25 +126,26 @@ registration/signin callout is shown or whether the user avatar is shown.
 				<content select=".content"></content>
 
 				<template is="dom-if" if="{{showUserStatus}}">
-					<div class="user-status">
+					<div class="user-status collapsed">
 						<template is="dom-if" if="{{userLoggedIn}}">
 							<a href="{{userAvatarHref}}">
-									<figure>
-										<img src="{{userAvatarSrc}}" alt="{{userName}}">
+								<figure>
+									<img src="{{userAvatarSrc}}" alt="{{userName}}">
 								</figure>
 							</a>
 							<div class="overlay"></div>
-							<content select=".drawer"></content>
+							<ul class="drawer">
+								<content select=".drawer-li"></content>
+							</ul>
 						</template>
 
 						<template is="dom-if" if="{{!userLoggedIn}}">
-								<div class="register-cta">
-									<a href="#">Register</a> or <a href="#">Login</a>
-								</div>
+							<div class="register-cta">
+								<a href="#">Register</a> or <a href="#">Login</a>
+							</div>
 						</template>
 					</div>
 				</template>
-
 			</div>
 		</div>
 	</template>

--- a/gh-pages/vendor/wikia-style-guide/dist/components/top-bar/top-bar.html
+++ b/gh-pages/vendor/wikia-style-guide/dist/components/top-bar/top-bar.html
@@ -18,115 +18,115 @@ shown or not. If `showUserStatus` is true, then the `userLoggedIn` attribute wil
 registration/signin callout is shown or whether the user avatar is shown.
 -->
 <dom-module id="top-bar">
-	<style>
-		[unresolved] {
-			visibility: hidden;
-		}
-
-		:host {
-			display: block;
-			background-color: #fff;
-			border-bottom: 1px solid #ccc;
-			height: 46px;
-			position: fixed;
-			width: 100%;
-			z-index: 9999999;
-		}
-
-		.logo {
-			fill: #092344;
-			width: 82px;
-		}
-
-		.user-status {
-			float: right;
-		}
-
-		.user-status figure {
-			margin-top: 3px;
-			width: 36px;
-			height: 36px;
-			border-radius: 50%;
-			overflow: hidden;
-		}
-
-		.user-status figure img {
-			width: 100%;
-			height: auto;
-		}
-
-		.register-cta {
-			margin-top: 10px;
-		}
-
-		.overlay {
-			/*@include perfect-square(100%);*/
-			background-color: black;
-			left: 0;
-			position: fixed;
-			top: 0;
-			z-index: 1000; /* TODO - firgure out number from mercury app */
-		}
-
-		.drawer {
-			list-style: none;
-			overflow: hidden;
-			position: fixed;
-			right: 0;
-			top: 0;
-			transition: height .1s;
-			width: 100%;
-			z-index: 1000; /* TODO - firgure out number from mercury app */
-		}
-
-		.drawer a {
-			/*@extend .touch-active;*/
-			display: block;
-			overflow: hidden;
-			padding: 0.625rem 0.8125rem; /* TODO - this is done with rem-calc in mercury */
-			text-overflow: ellipsis;
-			width: 100%;
-		}
-
-		li {
-			background-color: #fff;
-			border-bottom: rem-calc(1) solid #d0d0d0;
-		}
-
-		.collapsed .drawer {
-			height: 0;
-		}
-
-		.collapsed .overlay {
-			opacity: 0;
-			transition: visibility 0s 0.1s, opacity 0.1s; /* TODO - mercury uses variables for these values */
-			visibility: hidden;
-		}
-
-		.visible .drawer {
-			/* This is an arbitrary number larger than the combined height of the
-			li children, so that transition animation works. With height: auto,
-			it wouldn't be guaranteed to work. */
-			height: 100px;
-		}
-
-		.visible .overlay {
-			opacity: 0.5; /* TODO - mercury uses variables for these values */
-			transition: opacity 0.1s; /* TODO - mercury uses variables for these values */
-			visibility: visible;
-		}
-	</style>
-
 	<template>
+		<style>
+			[unresolved] {
+				visibility: hidden;
+			}
+
+			:host {
+				display: block;
+				background-color: #fff;
+				border-bottom: 1px solid #ccc;
+				height: 46px;
+				position: fixed;
+				width: 100%;
+				z-index: 9999999;
+			}
+
+			.logo {
+				fill: #092344;
+				width: 82px;
+			}
+
+			.user-status {
+				float: right;
+			}
+
+			.user-status figure {
+				margin-top: 3px;
+				width: 36px;
+				height: 36px;
+				border-radius: 50%;
+				overflow: hidden;
+			}
+
+			.user-status figure img {
+				width: 100%;
+				height: auto;
+			}
+
+			.register-cta {
+				margin-top: 10px;
+			}
+
+			.overlay {
+				/*@include perfect-square(100%);*/
+				background-color: black;
+				left: 0;
+				position: fixed;
+				top: 0;
+				z-index: 1000; /* TODO - firgure out number from mercury app */
+			}
+
+			.drawer {
+				list-style: none;
+				overflow: hidden;
+				position: fixed;
+				right: 0;
+				top: 0;
+				transition: height .1s;
+				width: 100%;
+				z-index: 1000; /* TODO - firgure out number from mercury app */
+			}
+
+			.drawer a {
+				/*@extend .touch-active;*/
+				display: block;
+				overflow: hidden;
+				padding: 0.625rem 0.8125rem; /* TODO - this is done with rem-calc in mercury */
+				text-overflow: ellipsis;
+				width: 100%;
+			}
+
+			.drawer ::content li {
+				background-color: #fff;
+				border-bottom: 0.0625rem solid #d0d0d0;
+			}
+
+			.collapsed .drawer {
+				height: 0;
+			}
+
+			.collapsed .overlay {
+				opacity: 0;
+				transition: visibility 0s 0.1s, opacity 0.1s; /* TODO - mercury uses variables for these values */
+				visibility: hidden;
+			}
+
+			.visible .drawer {
+				/* This is an arbitrary number larger than the combined height of the
+				li children, so that transition animation works. With height: auto,
+				it wouldn't be guaranteed to work. */
+				height: 100px;
+			}
+
+			.visible .overlay {
+				opacity: 0.5; /* TODO - mercury uses variables for these values */
+				transition: opacity 0.1s; /* TODO - mercury uses variables for these values */
+				visibility: visible;
+			}
+		</style>
+
 		<div class="row">
 			<div class="large-12 columns">
 				<a href="{{logoHref}}"><img src="{{logoSrc}}" alt="Wikia" class="logo left"></a>
 
 				<!-- Catch all for transcluded content -->
-				<content select=".content"></content>
+				<content select=".default-content"></content>
 
 				<template is="dom-if" if="{{showUserStatus}}">
-					<div class="user-status collapsed">
+					<div class="user-status visible">
 						<template is="dom-if" if="{{userLoggedIn}}">
 							<a href="{{userAvatarHref}}">
 								<figure>

--- a/gh-pages/vendor/wikia-style-guide/dist/components/top-bar/top-bar.html
+++ b/gh-pages/vendor/wikia-style-guide/dist/components/top-bar/top-bar.html
@@ -25,9 +25,9 @@ registration/signin callout is shown or whether the user avatar is shown.
 			}
 
 			:host {
-				display: block;
 				background-color: #fff;
 				border-bottom: 1px solid #ccc;
+				display: block;
 				height: 46px;
 				position: fixed;
 				width: 100%;

--- a/gh-pages/vendor/wikia-style-guide/dist/components/user-status/user-status.html
+++ b/gh-pages/vendor/wikia-style-guide/dist/components/user-status/user-status.html
@@ -1,0 +1,124 @@
+<dom-module id="user-status">
+	<template>
+		<style>
+			:host {
+				float: right;
+			}
+
+			figure {
+				border-radius: 50%;
+				height: 28px;
+				margin-top: 7px;
+				overflow: hidden;
+				width: 28px;
+			}
+
+			figure img {
+				height: auto;
+				width: 100%;
+			}
+
+			.register-cta {
+				margin-top: 10px;
+			}
+
+			.overlay {
+				/*@include perfect-square(100%);*/ /* TODO - uncomment and fix */
+				background-color: black;
+				left: 0;
+				position: fixed;
+				top: 0;
+				z-index: 1000;
+			}
+
+			.drawer {
+				list-style: none;
+				overflow: hidden;
+				position: fixed;
+				right: 0;
+				top: 0;
+				transition: height .1s;
+				width: 100%;
+				z-index: 1000;
+			}
+
+			.drawer a {
+				/*@extend .touch-active;*/  /* TODO - uncomment and fix */
+				display: block;
+				overflow: hidden;
+				padding: 0.625rem 0.8125rem;
+				text-overflow: ellipsis;
+				width: 100%;
+			}
+
+			.drawer ::content li {
+				background-color: #fff;
+				border-bottom: 0.0625rem solid #d0d0d0;
+			}
+
+			.drawer {
+				height: 0;
+			}
+
+			.overlay {
+				opacity: 0;
+				transition: visibility 0s 0.1s, opacity 0.1s;
+				visibility: hidden;
+			}
+
+			:host.visible .drawer {
+				/* This is an arbitrary number larger than the combined height of the
+				li children, so that transition animation works. With height: auto,
+				it wouldn't be guaranteed to work. */
+				height: 100px;
+			}
+
+			:host.visible .overlay {
+				opacity: 0.5;
+				transition: opacity 0.1s;
+				visibility: visible;
+			}
+		</style>
+
+		<template is="dom-if" if="{{userLoggedIn}}">
+			<a href="{{userAvatarHref}}">
+				<figure>
+					<img src="{{userAvatarSrc}}" alt="{{userName}}">
+				</figure>
+			</a>
+			<div class="overlay"></div>
+			<ul class="drawer">
+				<content select=".drawer-li"></content>
+			</ul>
+		</template>
+
+		<template is="dom-if" if="{{!userLoggedIn}}">
+			<div class="register-cta">
+				<span class="show-for-large-up"><a href="#">Register</a> or <a href="#">Login</a></span>
+				<figure class="hide-for-large-up">
+					<img src="{{anonAvatarSrc}}" alt="Register or login">
+				</figure>
+			</div>
+		</template>
+	</template>
+
+</dom-module>
+
+<script>
+	(function () {
+		Polymer({
+			is: 'user-status',
+			properties: {
+				userAvatarHref: String,
+				userAvatarSrc: String,
+				userName: String,
+				anonAvatarSrc: String,
+				userLoggedIn: {
+					type: Boolean,
+					value: false,
+					reflectToAttribute: true
+				}
+			}
+		});
+	}());
+</script>

--- a/gh-pages/vendor/wikia-style-guide/dist/components/user-status/user-status.html
+++ b/gh-pages/vendor/wikia-style-guide/dist/components/user-status/user-status.html
@@ -77,9 +77,6 @@
 					top: 46px;
 					width: 150px;
 				}
-
-				:host.visible .drawer {
-				}
 			}
 
 			.overlay {

--- a/gh-pages/vendor/wikia-style-guide/dist/components/user-status/user-status.html
+++ b/gh-pages/vendor/wikia-style-guide/dist/components/user-status/user-status.html
@@ -50,13 +50,18 @@
 				max-height: 600px;
 			}
 
-			.drawer a {
-				/*@extend .touch-active;*/  /* TODO - uncomment and fix */
+			.drawer ::content a {
 				display: block;
+				height: auto;
+				line-height: normal;
 				overflow: hidden;
 				padding: 0.625rem 0.8125rem;
 				text-overflow: ellipsis;
 				width: 100%;
+			}
+
+			.drawer ::content a:active {
+				background-color: #F2F6FA;
 			}
 
 			.drawer ::content li {

--- a/gh-pages/vendor/wikia-style-guide/dist/components/user-status/user-status.html
+++ b/gh-pages/vendor/wikia-style-guide/dist/components/user-status/user-status.html
@@ -121,10 +121,10 @@
 
 		<template is="dom-if" if="{{!userLoggedIn}}">
 			<div class="register-cta">
-				<span class="show-for-large-up"><a href="#">Register</a> or <a href="#">Login</a></span>
+				<span class="show-for-large-up"><a href="#">Register</a> or <a href="#">Log in</a></span>
 				<figure class="hide-for-large-up">
 					<a href="{{anonAvatarHref}}">
-						<img src="{{anonAvatarSrc}}" alt="Register or login">
+						<img src="{{anonAvatarSrc}}" alt="Register or log in">
 					</a>
 				</figure>
 			</div>

--- a/gh-pages/vendor/wikia-style-guide/dist/components/user-status/user-status.html
+++ b/gh-pages/vendor/wikia-style-guide/dist/components/user-status/user-status.html
@@ -13,6 +13,10 @@
 				width: 28px;
 			}
 
+			figure a {
+				display: block;
+			}
+
 			figure img {
 				height: auto;
 				width: 100%;
@@ -20,6 +24,10 @@
 
 			.register-cta {
 				margin-top: 10px;
+			}
+
+			.logged-in-wrapper {
+				cursor: pointer;
 			}
 
 			.overlay {
@@ -61,9 +69,16 @@
 			}
 
 			.overlay {
+				background-color: black;
+				height: 100%;
+				left: 0;
 				opacity: 0;
+				position: fixed;
+				top: 0;
 				transition: visibility 0s 0.1s, opacity 0.1s;
 				visibility: hidden;
+				width: 100%;
+				z-index: 800;
 			}
 
 			:host.visible .drawer {
@@ -81,22 +96,24 @@
 		</style>
 
 		<template is="dom-if" if="{{userLoggedIn}}">
-			<a href="{{userAvatarHref}}">
-				<figure>
+			<div class="logged-in-wrapper">
+				<figure id="special" on-click="toggleDropdown">
 					<img src="{{userAvatarSrc}}" alt="{{userName}}">
 				</figure>
-			</a>
-			<div class="overlay"></div>
-			<ul class="drawer">
-				<content select=".drawer-li"></content>
-			</ul>
+				<div class="overlay" on-click="toggleDropdown"></div>
+				<ul class="drawer">
+					<content></content>
+				</ul>
+			</div>
 		</template>
 
 		<template is="dom-if" if="{{!userLoggedIn}}">
 			<div class="register-cta">
 				<span class="show-for-large-up"><a href="#">Register</a> or <a href="#">Login</a></span>
 				<figure class="hide-for-large-up">
-					<img src="{{anonAvatarSrc}}" alt="Register or login">
+					<a href="{{anonAvatarHref}}">
+						<img src="{{anonAvatarSrc}}" alt="Register or login">
+					</a>
 				</figure>
 			</div>
 		</template>
@@ -109,15 +126,24 @@
 		Polymer({
 			is: 'user-status',
 			properties: {
-				userAvatarHref: String,
 				userAvatarSrc: String,
 				userName: String,
 				anonAvatarSrc: String,
+				anonAvatarHref: String,
 				userLoggedIn: {
 					type: Boolean,
 					value: false,
 					reflectToAttribute: true
+				},
+				collapsed: {
+					type: Boolean,
+					value: true,
+					reflectToAttribute: true
 				}
+			},
+			toggleDropdown: function () {
+				var isVisible = Array.prototype.indexOf.call(this.classList, 'visible') > -1;
+				this.toggleClass('visible', !isVisible);
 			}
 		});
 	}());

--- a/gh-pages/vendor/wikia-style-guide/dist/components/user-status/user-status.html
+++ b/gh-pages/vendor/wikia-style-guide/dist/components/user-status/user-status.html
@@ -93,6 +93,14 @@
 				transition: opacity 0.1s;
 				visibility: visible;
 			}
+
+			/* Don't black out the rest of the screen on larger devices */
+			@media only screen and (min-width: 40.063em) {
+				:host.visible .overlay {
+					opacity: 0;
+				}
+			}
+
 		</style>
 
 		<template is="dom-if" if="{{userLoggedIn}}">

--- a/gh-pages/vendor/wikia-style-guide/dist/components/user-status/user-status.html
+++ b/gh-pages/vendor/wikia-style-guide/dist/components/user-status/user-status.html
@@ -3,6 +3,7 @@
 		<style>
 			:host {
 				float: right;
+				position: relative;
 			}
 
 			figure {
@@ -30,24 +31,23 @@
 				cursor: pointer;
 			}
 
-			.overlay {
-				/*@include perfect-square(100%);*/ /* TODO - uncomment and fix */
-				background-color: black;
-				left: 0;
-				position: fixed;
-				top: 0;
-				z-index: 1000;
-			}
-
 			.drawer {
 				list-style: none;
+				max-height: 0;
 				overflow: hidden;
 				position: fixed;
 				right: 0;
 				top: 0;
-				transition: height .1s;
+				transition: max-height .3s;
 				width: 100%;
 				z-index: 1000;
+			}
+
+			:host.visible .drawer {
+				/* This is an arbitrary number larger than the combined height of the
+				li children, so that transition animation works. With max-height: auto,
+				it wouldn't be guaranteed to work. */
+				max-height: 600px;
 			}
 
 			.drawer a {
@@ -61,11 +61,20 @@
 
 			.drawer ::content li {
 				background-color: #fff;
-				border-bottom: 0.0625rem solid #d0d0d0;
+				border: solid #d0d0d0;
+				border-width: 0 1px 1px 1px;
 			}
 
-			.drawer {
-				height: 0;
+			@media only screen and (min-width: 40.063em) {
+				.drawer {
+					position: absolute;
+					right: 0;
+					top: 46px;
+					width: 150px;
+				}
+
+				:host.visible .drawer {
+				}
 			}
 
 			.overlay {
@@ -75,22 +84,15 @@
 				opacity: 0;
 				position: fixed;
 				top: 0;
-				transition: visibility 0s 0.1s, opacity 0.1s;
+				transition: visibility 0s 0.3s, opacity 0.3s;
 				visibility: hidden;
 				width: 100%;
 				z-index: 800;
 			}
 
-			:host.visible .drawer {
-				/* This is an arbitrary number larger than the combined height of the
-				li children, so that transition animation works. With height: auto,
-				it wouldn't be guaranteed to work. */
-				height: 100px;
-			}
-
 			:host.visible .overlay {
 				opacity: 0.5;
-				transition: opacity 0.1s;
+				transition: opacity 0.3s;
 				visibility: visible;
 			}
 

--- a/src/components/top-bar/top-bar.html
+++ b/src/components/top-bar/top-bar.html
@@ -7,110 +7,112 @@ This component provides a default top bar for Wikia websites and includes handli
 to action for anonymous users.
 
 Example:
-  <top-bar
-    user-avatar-src="foo.png" user-profile-href="http://wwww.wikia.com" user-name="Wikia User"
-    logo-href="http://www.wikia.com" logo-src="logo.svg" user-logged-in show-user-status>
-    <h1>Hello World!</h1>
-  </top-bar>
+	<top-bar
+		user-avatar-src="foo.png" user-profile-href="http://wwww.wikia.com" user-name="Wikia User"
+		logo-href="http://www.wikia.com" logo-src="logo.svg" user-logged-in show-user-status>
+		<h1>Hello World!</h1>
+	</top-bar>
 
 You can use the `showUserStatus` to control whether or not the callout for user registration/user logged in avatar is
 shown or not. If `showUserStatus` is true, then the `userLoggedIn` attribute will control whether or not the
 registration/signin callout is shown or whether the user avatar is shown.
 -->
 <dom-module id="top-bar">
-  <style>
-    [unresolved] {
-      visibility: hidden;
-    }
+	<style>
+		[unresolved] {
+			visibility: hidden;
+		}
 
-    :host {
-      display: block;
-      background-color: #fff;
-      border-bottom: 1px solid #ccc;
-      height: 46px;
-      position: fixed;
-      width: 100%;
-      z-index: 9999999;
-    }
+		:host {
+			display: block;
+			background-color: #fff;
+			border-bottom: 1px solid #ccc;
+			height: 46px;
+			position: fixed;
+			width: 100%;
+			z-index: 9999999;
+		}
 
-    .logo {
-      fill: #092344;
-      width: 82px;
-    }
+		.logo {
+			fill: #092344;
+			width: 82px;
+		}
 
-    .user-status {
-      float: right;
-    }
+		.user-status {
+			float: right;
+		}
 
-    .user-status figure {
-      margin-top: 3px;
-      width: 36px;
-      height: 36px;
-      border-radius: 50%;
-      overflow: hidden;
-    }
+		.user-status figure {
+			margin-top: 3px;
+			width: 36px;
+			height: 36px;
+			border-radius: 50%;
+			overflow: hidden;
+		}
 
-    .user-status figure img {
-      width: 100%;
-      height: auto;
-    }
+		.user-status figure img {
+			width: 100%;
+			height: auto;
+		}
 
-    .register-cta {
-      margin-top: 10px;
-    }
-  </style>
+		.register-cta {
+			margin-top: 10px;
+		}
+	</style>
 
-  <template>
-    <div class="row">
-      <div class="large-12 columns">
-        <a href="{{logoHref}}"><img src="{{logoSrc}}" alt="Wikia" class="logo left"></a>
+	<template>
+		<div class="row">
+			<div class="large-12 columns">
+				<a href="{{logoHref}}"><img src="{{logoSrc}}" alt="Wikia" class="logo left"></a>
 
-        <!-- Catch all for transcluded content -->
-        <content></content>
+				<!-- Catch all for transcluded content -->
+				<content select=".content"></content>
 
-        <template is="dom-if" if="{{showUserStatus}}">
-          <div class="user-status">
-            <template is="dom-if" if="{{userLoggedIn}}">
-              <a href="{{userAvatarHref}}">
-                  <figure>
-                    <img src="{{userAvatarSrc}}" alt="{{userName}}">
-                </figure>
-              </a>
-            </template>
+				<template is="dom-if" if="{{showUserStatus}}">
+					<div class="user-status">
+						<template is="dom-if" if="{{userLoggedIn}}">
+							<a href="{{userAvatarHref}}">
+									<figure>
+										<img src="{{userAvatarSrc}}" alt="{{userName}}">
+								</figure>
+							</a>
+							<div class="overlay"></div>
+							<content select=".drawer"></content>
+						</template>
 
-            <template is="dom-if" if="{{!userLoggedIn}}">
-                <div class="register-cta">
-                  <a href="#">Register</a> or <a href="#">Login</a>
-                </div>
-            </template>
-          </div>
-        </template>
+						<template is="dom-if" if="{{!userLoggedIn}}">
+								<div class="register-cta">
+									<a href="#">Register</a> or <a href="#">Login</a>
+								</div>
+						</template>
+					</div>
+				</template>
 
-      </div>
-    </div>
-  </template>
+			</div>
+		</div>
+	</template>
 </dom-module>
 
 <script>
-  (function () {
-    Polymer({
-      is: 'top-bar',
-      properties: {
-        userAvatarSrc: String,
-        userProfileHref: String,
-        userName: String,
-        logoHref: String,
-        logoSrc: String,
-        userLoggedIn: {
-          type: Boolean,
-          value: false,
-          reflectToAttribute: true
-        },
-        showUserStatus: {
-          type: Boolean,
-          value: false
-        }
-      }
-    });
-  }());
+	(function () {
+		Polymer({
+			is: 'top-bar',
+			properties: {
+				userAvatarSrc: String,
+				userProfileHref: String,
+				userName: String,
+				logoHref: String,
+				logoSrc: String,
+				userLoggedIn: {
+					type: Boolean,
+					value: false,
+					reflectToAttribute: true
+				},
+				showUserStatus: {
+					type: Boolean,
+					value: false
+				}
+			}
+		});
+	}());
 </script>

--- a/src/components/top-bar/top-bar.html
+++ b/src/components/top-bar/top-bar.html
@@ -38,84 +38,6 @@ registration/signin callout is shown or whether the user avatar is shown.
 				fill: #092344;
 				width: 82px;
 			}
-
-			.user-status {
-				float: right;
-			}
-
-			.user-status figure {
-				margin-top: 3px;
-				width: 36px;
-				height: 36px;
-				border-radius: 50%;
-				overflow: hidden;
-			}
-
-			.user-status figure img {
-				width: 100%;
-				height: auto;
-			}
-
-			.register-cta {
-				margin-top: 10px;
-			}
-
-			.overlay {
-				/*@include perfect-square(100%);*/
-				background-color: black;
-				left: 0;
-				position: fixed;
-				top: 0;
-				z-index: 1000; /* TODO - firgure out number from mercury app */
-			}
-
-			.drawer {
-				list-style: none;
-				overflow: hidden;
-				position: fixed;
-				right: 0;
-				top: 0;
-				transition: height .1s;
-				width: 100%;
-				z-index: 1000; /* TODO - firgure out number from mercury app */
-			}
-
-			.drawer a {
-				/*@extend .touch-active;*/
-				display: block;
-				overflow: hidden;
-				padding: 0.625rem 0.8125rem; /* TODO - this is done with rem-calc in mercury */
-				text-overflow: ellipsis;
-				width: 100%;
-			}
-
-			.drawer ::content li {
-				background-color: #fff;
-				border-bottom: 0.0625rem solid #d0d0d0;
-			}
-
-			.collapsed .drawer {
-				height: 0;
-			}
-
-			.collapsed .overlay {
-				opacity: 0;
-				transition: visibility 0s 0.1s, opacity 0.1s; /* TODO - mercury uses variables for these values */
-				visibility: hidden;
-			}
-
-			.visible .drawer {
-				/* This is an arbitrary number larger than the combined height of the
-				li children, so that transition animation works. With height: auto,
-				it wouldn't be guaranteed to work. */
-				height: 100px;
-			}
-
-			.visible .overlay {
-				opacity: 0.5; /* TODO - mercury uses variables for these values */
-				transition: opacity 0.1s; /* TODO - mercury uses variables for these values */
-				visibility: visible;
-			}
 		</style>
 
 		<div class="row">
@@ -123,29 +45,7 @@ registration/signin callout is shown or whether the user avatar is shown.
 				<a href="{{logoHref}}"><img src="{{logoSrc}}" alt="Wikia" class="logo left"></a>
 
 				<!-- Catch all for transcluded content -->
-				<content select=".default-content"></content>
-
-				<template is="dom-if" if="{{showUserStatus}}">
-					<div class="user-status visible">
-						<template is="dom-if" if="{{userLoggedIn}}">
-							<a href="{{userAvatarHref}}">
-								<figure>
-									<img src="{{userAvatarSrc}}" alt="{{userName}}">
-								</figure>
-							</a>
-							<div class="overlay"></div>
-							<ul class="drawer">
-								<content select=".drawer-li"></content>
-							</ul>
-						</template>
-
-						<template is="dom-if" if="{{!userLoggedIn}}">
-							<div class="register-cta">
-								<a href="#">Register</a> or <a href="#">Login</a>
-							</div>
-						</template>
-					</div>
-				</template>
+				<content></content>
 			</div>
 		</div>
 	</template>
@@ -156,16 +56,8 @@ registration/signin callout is shown or whether the user avatar is shown.
 		Polymer({
 			is: 'top-bar',
 			properties: {
-				userAvatarSrc: String,
-				userProfileHref: String,
-				userName: String,
 				logoHref: String,
 				logoSrc: String,
-				userLoggedIn: {
-					type: Boolean,
-					value: false,
-					reflectToAttribute: true
-				},
 				showUserStatus: {
 					type: Boolean,
 					value: false

--- a/src/components/top-bar/top-bar.html
+++ b/src/components/top-bar/top-bar.html
@@ -58,6 +58,63 @@ registration/signin callout is shown or whether the user avatar is shown.
 		.register-cta {
 			margin-top: 10px;
 		}
+
+		.overlay {
+			/*@include perfect-square(100%);*/
+			background-color: black;
+			left: 0;
+			position: fixed;
+			top: 0;
+			z-index: 1000; /* TODO - firgure out number from mercury app */
+		}
+
+		.drawer {
+			list-style: none;
+			overflow: hidden;
+			position: fixed;
+			right: 0;
+			top: 0;
+			transition: height .1s;
+			width: 100%;
+			z-index: 1000; /* TODO - firgure out number from mercury app */
+		}
+
+		.drawer a {
+			/*@extend .touch-active;*/
+			display: block;
+			overflow: hidden;
+			padding: 0.625rem 0.8125rem; /* TODO - this is done with rem-calc in mercury */
+			text-overflow: ellipsis;
+			width: 100%;
+		}
+
+		li {
+			background-color: #fff;
+			border-bottom: rem-calc(1) solid #d0d0d0;
+		}
+
+		.collapsed .drawer {
+			height: 0;
+		}
+
+		.collapsed .overlay {
+			opacity: 0;
+			transition: visibility 0s 0.1s, opacity 0.1s; /* TODO - mercury uses variables for these values */
+			visibility: hidden;
+		}
+
+		.visible .drawer {
+			/* This is an arbitrary number larger than the combined height of the
+			li children, so that transition animation works. With height: auto,
+			it wouldn't be guaranteed to work. */
+			height: 100px;
+		}
+
+		.visible .overlay {
+			opacity: 0.5; /* TODO - mercury uses variables for these values */
+			transition: opacity 0.1s; /* TODO - mercury uses variables for these values */
+			visibility: visible;
+		}
 	</style>
 
 	<template>
@@ -69,25 +126,26 @@ registration/signin callout is shown or whether the user avatar is shown.
 				<content select=".content"></content>
 
 				<template is="dom-if" if="{{showUserStatus}}">
-					<div class="user-status">
+					<div class="user-status collapsed">
 						<template is="dom-if" if="{{userLoggedIn}}">
 							<a href="{{userAvatarHref}}">
-									<figure>
-										<img src="{{userAvatarSrc}}" alt="{{userName}}">
+								<figure>
+									<img src="{{userAvatarSrc}}" alt="{{userName}}">
 								</figure>
 							</a>
 							<div class="overlay"></div>
-							<content select=".drawer"></content>
+							<ul class="drawer">
+								<content select=".drawer-li"></content>
+							</ul>
 						</template>
 
 						<template is="dom-if" if="{{!userLoggedIn}}">
-								<div class="register-cta">
-									<a href="#">Register</a> or <a href="#">Login</a>
-								</div>
+							<div class="register-cta">
+								<a href="#">Register</a> or <a href="#">Login</a>
+							</div>
 						</template>
 					</div>
 				</template>
-
 			</div>
 		</div>
 	</template>

--- a/src/components/top-bar/top-bar.html
+++ b/src/components/top-bar/top-bar.html
@@ -18,115 +18,115 @@ shown or not. If `showUserStatus` is true, then the `userLoggedIn` attribute wil
 registration/signin callout is shown or whether the user avatar is shown.
 -->
 <dom-module id="top-bar">
-	<style>
-		[unresolved] {
-			visibility: hidden;
-		}
-
-		:host {
-			display: block;
-			background-color: #fff;
-			border-bottom: 1px solid #ccc;
-			height: 46px;
-			position: fixed;
-			width: 100%;
-			z-index: 9999999;
-		}
-
-		.logo {
-			fill: #092344;
-			width: 82px;
-		}
-
-		.user-status {
-			float: right;
-		}
-
-		.user-status figure {
-			margin-top: 3px;
-			width: 36px;
-			height: 36px;
-			border-radius: 50%;
-			overflow: hidden;
-		}
-
-		.user-status figure img {
-			width: 100%;
-			height: auto;
-		}
-
-		.register-cta {
-			margin-top: 10px;
-		}
-
-		.overlay {
-			/*@include perfect-square(100%);*/
-			background-color: black;
-			left: 0;
-			position: fixed;
-			top: 0;
-			z-index: 1000; /* TODO - firgure out number from mercury app */
-		}
-
-		.drawer {
-			list-style: none;
-			overflow: hidden;
-			position: fixed;
-			right: 0;
-			top: 0;
-			transition: height .1s;
-			width: 100%;
-			z-index: 1000; /* TODO - firgure out number from mercury app */
-		}
-
-		.drawer a {
-			/*@extend .touch-active;*/
-			display: block;
-			overflow: hidden;
-			padding: 0.625rem 0.8125rem; /* TODO - this is done with rem-calc in mercury */
-			text-overflow: ellipsis;
-			width: 100%;
-		}
-
-		li {
-			background-color: #fff;
-			border-bottom: rem-calc(1) solid #d0d0d0;
-		}
-
-		.collapsed .drawer {
-			height: 0;
-		}
-
-		.collapsed .overlay {
-			opacity: 0;
-			transition: visibility 0s 0.1s, opacity 0.1s; /* TODO - mercury uses variables for these values */
-			visibility: hidden;
-		}
-
-		.visible .drawer {
-			/* This is an arbitrary number larger than the combined height of the
-			li children, so that transition animation works. With height: auto,
-			it wouldn't be guaranteed to work. */
-			height: 100px;
-		}
-
-		.visible .overlay {
-			opacity: 0.5; /* TODO - mercury uses variables for these values */
-			transition: opacity 0.1s; /* TODO - mercury uses variables for these values */
-			visibility: visible;
-		}
-	</style>
-
 	<template>
+		<style>
+			[unresolved] {
+				visibility: hidden;
+			}
+
+			:host {
+				display: block;
+				background-color: #fff;
+				border-bottom: 1px solid #ccc;
+				height: 46px;
+				position: fixed;
+				width: 100%;
+				z-index: 9999999;
+			}
+
+			.logo {
+				fill: #092344;
+				width: 82px;
+			}
+
+			.user-status {
+				float: right;
+			}
+
+			.user-status figure {
+				margin-top: 3px;
+				width: 36px;
+				height: 36px;
+				border-radius: 50%;
+				overflow: hidden;
+			}
+
+			.user-status figure img {
+				width: 100%;
+				height: auto;
+			}
+
+			.register-cta {
+				margin-top: 10px;
+			}
+
+			.overlay {
+				/*@include perfect-square(100%);*/
+				background-color: black;
+				left: 0;
+				position: fixed;
+				top: 0;
+				z-index: 1000; /* TODO - firgure out number from mercury app */
+			}
+
+			.drawer {
+				list-style: none;
+				overflow: hidden;
+				position: fixed;
+				right: 0;
+				top: 0;
+				transition: height .1s;
+				width: 100%;
+				z-index: 1000; /* TODO - firgure out number from mercury app */
+			}
+
+			.drawer a {
+				/*@extend .touch-active;*/
+				display: block;
+				overflow: hidden;
+				padding: 0.625rem 0.8125rem; /* TODO - this is done with rem-calc in mercury */
+				text-overflow: ellipsis;
+				width: 100%;
+			}
+
+			.drawer ::content li {
+				background-color: #fff;
+				border-bottom: 0.0625rem solid #d0d0d0;
+			}
+
+			.collapsed .drawer {
+				height: 0;
+			}
+
+			.collapsed .overlay {
+				opacity: 0;
+				transition: visibility 0s 0.1s, opacity 0.1s; /* TODO - mercury uses variables for these values */
+				visibility: hidden;
+			}
+
+			.visible .drawer {
+				/* This is an arbitrary number larger than the combined height of the
+				li children, so that transition animation works. With height: auto,
+				it wouldn't be guaranteed to work. */
+				height: 100px;
+			}
+
+			.visible .overlay {
+				opacity: 0.5; /* TODO - mercury uses variables for these values */
+				transition: opacity 0.1s; /* TODO - mercury uses variables for these values */
+				visibility: visible;
+			}
+		</style>
+
 		<div class="row">
 			<div class="large-12 columns">
 				<a href="{{logoHref}}"><img src="{{logoSrc}}" alt="Wikia" class="logo left"></a>
 
 				<!-- Catch all for transcluded content -->
-				<content select=".content"></content>
+				<content select=".default-content"></content>
 
 				<template is="dom-if" if="{{showUserStatus}}">
-					<div class="user-status collapsed">
+					<div class="user-status visible">
 						<template is="dom-if" if="{{userLoggedIn}}">
 							<a href="{{userAvatarHref}}">
 								<figure>

--- a/src/components/top-bar/top-bar.html
+++ b/src/components/top-bar/top-bar.html
@@ -25,9 +25,9 @@ registration/signin callout is shown or whether the user avatar is shown.
 			}
 
 			:host {
-				display: block;
 				background-color: #fff;
 				border-bottom: 1px solid #ccc;
+				display: block;
 				height: 46px;
 				position: fixed;
 				width: 100%;

--- a/src/components/user-status/user-status.html
+++ b/src/components/user-status/user-status.html
@@ -1,0 +1,124 @@
+<dom-module id="user-status">
+	<template>
+		<style>
+			:host {
+				float: right;
+			}
+
+			figure {
+				border-radius: 50%;
+				height: 28px;
+				margin-top: 7px;
+				overflow: hidden;
+				width: 28px;
+			}
+
+			figure img {
+				height: auto;
+				width: 100%;
+			}
+
+			.register-cta {
+				margin-top: 10px;
+			}
+
+			.overlay {
+				/*@include perfect-square(100%);*/ /* TODO - uncomment and fix */
+				background-color: black;
+				left: 0;
+				position: fixed;
+				top: 0;
+				z-index: 1000;
+			}
+
+			.drawer {
+				list-style: none;
+				overflow: hidden;
+				position: fixed;
+				right: 0;
+				top: 0;
+				transition: height .1s;
+				width: 100%;
+				z-index: 1000;
+			}
+
+			.drawer a {
+				/*@extend .touch-active;*/  /* TODO - uncomment and fix */
+				display: block;
+				overflow: hidden;
+				padding: 0.625rem 0.8125rem;
+				text-overflow: ellipsis;
+				width: 100%;
+			}
+
+			.drawer ::content li {
+				background-color: #fff;
+				border-bottom: 0.0625rem solid #d0d0d0;
+			}
+
+			.drawer {
+				height: 0;
+			}
+
+			.overlay {
+				opacity: 0;
+				transition: visibility 0s 0.1s, opacity 0.1s;
+				visibility: hidden;
+			}
+
+			:host.visible .drawer {
+				/* This is an arbitrary number larger than the combined height of the
+				li children, so that transition animation works. With height: auto,
+				it wouldn't be guaranteed to work. */
+				height: 100px;
+			}
+
+			:host.visible .overlay {
+				opacity: 0.5;
+				transition: opacity 0.1s;
+				visibility: visible;
+			}
+		</style>
+
+		<template is="dom-if" if="{{userLoggedIn}}">
+			<a href="{{userAvatarHref}}">
+				<figure>
+					<img src="{{userAvatarSrc}}" alt="{{userName}}">
+				</figure>
+			</a>
+			<div class="overlay"></div>
+			<ul class="drawer">
+				<content select=".drawer-li"></content>
+			</ul>
+		</template>
+
+		<template is="dom-if" if="{{!userLoggedIn}}">
+			<div class="register-cta">
+				<span class="show-for-large-up"><a href="#">Register</a> or <a href="#">Login</a></span>
+				<figure class="hide-for-large-up">
+					<img src="{{anonAvatarSrc}}" alt="Register or login">
+				</figure>
+			</div>
+		</template>
+	</template>
+
+</dom-module>
+
+<script>
+	(function () {
+		Polymer({
+			is: 'user-status',
+			properties: {
+				userAvatarHref: String,
+				userAvatarSrc: String,
+				userName: String,
+				anonAvatarSrc: String,
+				userLoggedIn: {
+					type: Boolean,
+					value: false,
+					reflectToAttribute: true
+				}
+			}
+		});
+	}());
+</script>

--- a/src/components/user-status/user-status.html
+++ b/src/components/user-status/user-status.html
@@ -77,9 +77,6 @@
 					top: 46px;
 					width: 150px;
 				}
-
-				:host.visible .drawer {
-				}
 			}
 
 			.overlay {

--- a/src/components/user-status/user-status.html
+++ b/src/components/user-status/user-status.html
@@ -50,13 +50,18 @@
 				max-height: 600px;
 			}
 
-			.drawer a {
-				/*@extend .touch-active;*/  /* TODO - uncomment and fix */
+			.drawer ::content a {
 				display: block;
+				height: auto;
+				line-height: normal;
 				overflow: hidden;
 				padding: 0.625rem 0.8125rem;
 				text-overflow: ellipsis;
 				width: 100%;
+			}
+
+			.drawer ::content a:active {
+				background-color: #F2F6FA;
 			}
 
 			.drawer ::content li {

--- a/src/components/user-status/user-status.html
+++ b/src/components/user-status/user-status.html
@@ -121,10 +121,10 @@
 
 		<template is="dom-if" if="{{!userLoggedIn}}">
 			<div class="register-cta">
-				<span class="show-for-large-up"><a href="#">Register</a> or <a href="#">Login</a></span>
+				<span class="show-for-large-up"><a href="#">Register</a> or <a href="#">Log in</a></span>
 				<figure class="hide-for-large-up">
 					<a href="{{anonAvatarHref}}">
-						<img src="{{anonAvatarSrc}}" alt="Register or login">
+						<img src="{{anonAvatarSrc}}" alt="Register or log in">
 					</a>
 				</figure>
 			</div>

--- a/src/components/user-status/user-status.html
+++ b/src/components/user-status/user-status.html
@@ -13,6 +13,10 @@
 				width: 28px;
 			}
 
+			figure a {
+				display: block;
+			}
+
 			figure img {
 				height: auto;
 				width: 100%;
@@ -20,6 +24,10 @@
 
 			.register-cta {
 				margin-top: 10px;
+			}
+
+			.logged-in-wrapper {
+				cursor: pointer;
 			}
 
 			.overlay {
@@ -61,9 +69,16 @@
 			}
 
 			.overlay {
+				background-color: black;
+				height: 100%;
+				left: 0;
 				opacity: 0;
+				position: fixed;
+				top: 0;
 				transition: visibility 0s 0.1s, opacity 0.1s;
 				visibility: hidden;
+				width: 100%;
+				z-index: 800;
 			}
 
 			:host.visible .drawer {
@@ -81,22 +96,24 @@
 		</style>
 
 		<template is="dom-if" if="{{userLoggedIn}}">
-			<a href="{{userAvatarHref}}">
-				<figure>
+			<div class="logged-in-wrapper">
+				<figure id="special" on-click="toggleDropdown">
 					<img src="{{userAvatarSrc}}" alt="{{userName}}">
 				</figure>
-			</a>
-			<div class="overlay"></div>
-			<ul class="drawer">
-				<content select=".drawer-li"></content>
-			</ul>
+				<div class="overlay" on-click="toggleDropdown"></div>
+				<ul class="drawer">
+					<content></content>
+				</ul>
+			</div>
 		</template>
 
 		<template is="dom-if" if="{{!userLoggedIn}}">
 			<div class="register-cta">
 				<span class="show-for-large-up"><a href="#">Register</a> or <a href="#">Login</a></span>
 				<figure class="hide-for-large-up">
-					<img src="{{anonAvatarSrc}}" alt="Register or login">
+					<a href="{{anonAvatarHref}}">
+						<img src="{{anonAvatarSrc}}" alt="Register or login">
+					</a>
 				</figure>
 			</div>
 		</template>
@@ -109,15 +126,24 @@
 		Polymer({
 			is: 'user-status',
 			properties: {
-				userAvatarHref: String,
 				userAvatarSrc: String,
 				userName: String,
 				anonAvatarSrc: String,
+				anonAvatarHref: String,
 				userLoggedIn: {
 					type: Boolean,
 					value: false,
 					reflectToAttribute: true
+				},
+				collapsed: {
+					type: Boolean,
+					value: true,
+					reflectToAttribute: true
 				}
+			},
+			toggleDropdown: function () {
+				var isVisible = Array.prototype.indexOf.call(this.classList, 'visible') > -1;
+				this.toggleClass('visible', !isVisible);
 			}
 		});
 	}());

--- a/src/components/user-status/user-status.html
+++ b/src/components/user-status/user-status.html
@@ -93,6 +93,14 @@
 				transition: opacity 0.1s;
 				visibility: visible;
 			}
+
+			/* Don't black out the rest of the screen on larger devices */
+			@media only screen and (min-width: 40.063em) {
+				:host.visible .overlay {
+					opacity: 0;
+				}
+			}
+
 		</style>
 
 		<template is="dom-if" if="{{userLoggedIn}}">

--- a/src/components/user-status/user-status.html
+++ b/src/components/user-status/user-status.html
@@ -3,6 +3,7 @@
 		<style>
 			:host {
 				float: right;
+				position: relative;
 			}
 
 			figure {
@@ -30,24 +31,23 @@
 				cursor: pointer;
 			}
 
-			.overlay {
-				/*@include perfect-square(100%);*/ /* TODO - uncomment and fix */
-				background-color: black;
-				left: 0;
-				position: fixed;
-				top: 0;
-				z-index: 1000;
-			}
-
 			.drawer {
 				list-style: none;
+				max-height: 0;
 				overflow: hidden;
 				position: fixed;
 				right: 0;
 				top: 0;
-				transition: height .1s;
+				transition: max-height .3s;
 				width: 100%;
 				z-index: 1000;
+			}
+
+			:host.visible .drawer {
+				/* This is an arbitrary number larger than the combined height of the
+				li children, so that transition animation works. With max-height: auto,
+				it wouldn't be guaranteed to work. */
+				max-height: 600px;
 			}
 
 			.drawer a {
@@ -61,11 +61,20 @@
 
 			.drawer ::content li {
 				background-color: #fff;
-				border-bottom: 0.0625rem solid #d0d0d0;
+				border: solid #d0d0d0;
+				border-width: 0 1px 1px 1px;
 			}
 
-			.drawer {
-				height: 0;
+			@media only screen and (min-width: 40.063em) {
+				.drawer {
+					position: absolute;
+					right: 0;
+					top: 46px;
+					width: 150px;
+				}
+
+				:host.visible .drawer {
+				}
 			}
 
 			.overlay {
@@ -75,22 +84,15 @@
 				opacity: 0;
 				position: fixed;
 				top: 0;
-				transition: visibility 0s 0.1s, opacity 0.1s;
+				transition: visibility 0s 0.3s, opacity 0.3s;
 				visibility: hidden;
 				width: 100%;
 				z-index: 800;
 			}
 
-			:host.visible .drawer {
-				/* This is an arbitrary number larger than the combined height of the
-				li children, so that transition animation works. With height: auto,
-				it wouldn't be guaranteed to work. */
-				height: 100px;
-			}
-
 			:host.visible .overlay {
 				opacity: 0.5;
-				transition: opacity 0.1s;
+				transition: opacity 0.3s;
 				visibility: visible;
 			}
 


### PR DESCRIPTION
This PR separates out the user status portion of the top-bar into it's own component, which includes a drop-down menu. 

I tried to annotate all the places where I actually change the code (as opposed to the compiled files)

Note: before we merge this we should set the style guide version to not include the user status. I've enabled it for now for the sake of code review. 
