### PR TITLE
adding style guide colors to anchors inside component

### DIFF
--- a/dist/components/user-status/user-status.html
+++ b/dist/components/user-status/user-status.html
@@ -27,6 +27,16 @@ The `userLoggedIn` attribute will control whether the registration/signin callou
 				position: relative;
 			}
 
+			a {
+				color: #1A5EB8;
+				text-decoration: none;
+				line-height: inherit;
+			}
+
+			a:hover, a:focus {
+				color: #081e3a;
+			}
+
 			figure {
 				border-radius: 50%;
 				margin: 0;

--- a/gh-pages/vendor/wikia-style-guide/dist/components/user-status/user-status.html
+++ b/gh-pages/vendor/wikia-style-guide/dist/components/user-status/user-status.html
@@ -27,6 +27,16 @@ The `userLoggedIn` attribute will control whether the registration/signin callou
 				position: relative;
 			}
 
+			a {
+				color: #1A5EB8;
+				text-decoration: none;
+				line-height: inherit;
+			}
+
+			a:hover, a:focus {
+				color: #081e3a;
+			}
+
 			figure {
 				border-radius: 50%;
 				margin: 0;

--- a/src/components/user-status/user-status.html
+++ b/src/components/user-status/user-status.html
@@ -27,6 +27,16 @@ The `userLoggedIn` attribute will control whether the registration/signin callou
 				position: relative;
 			}
 
+			a {
+				color: #1A5EB8;
+				text-decoration: none;
+				line-height: inherit;
+			}
+
+			a:hover, a:focus {
+				color: #081e3a;
+			}
+
 			figure {
 				border-radius: 50%;
 				margin: 0;


### PR DESCRIPTION
This will make the anchor links in the new top-nav match the rest of the style-guide links on the page. It's necessary to re-declare the styles here due to scoped styling in shadow dom. 

This is somewhat of a temporary solution, as the ultimate goal is to create a base component with all the style-guide styles and build other polymer components off of it. 
