### PR TITLE
HG-878 adding ability to transclude text for the register cta

### DIFF
--- a/dist/components/import-built.html
+++ b/dist/components/import-built.html
@@ -6356,6 +6356,16 @@ this.fire('dom-change');
 				position: relative;
 			}
 
+			a {
+				color: #1A5EB8;
+				text-decoration: none;
+				line-height: inherit;
+			}
+
+			a:hover, a:focus {
+				color: #081e3a;
+			}
+
 			figure {
 				border-radius: 50%;
 				margin: 0;
@@ -6458,7 +6468,7 @@ this.fire('dom-change');
 					width: 150px;
 				}
 
-				.register-cta span {
+				.register-cta .long-text {
 					display: inline-block;
 				}
 
@@ -6483,7 +6493,9 @@ this.fire('dom-change');
 
 		<template is="dom-if" if="{{!userLoggedIn}}">
 			<div class="register-cta">
-				<span><a href="#">Register</a> or <a href="#">Log in</a></span>
+				<span class="long-text">
+					<content select=".register-cta-text"></content>
+				</span>
 				<figure>
 					<a href="{{anonAvatarHref}}">
 						<img src="{{anonAvatarSrc}}" alt="Register or log in">

--- a/dist/components/user-status/user-status.html
+++ b/dist/components/user-status/user-status.html
@@ -139,7 +139,7 @@ The `userLoggedIn` attribute will control whether the registration/signin callou
 					width: 150px;
 				}
 
-				.register-cta span {
+				.register-cta .long-text {
 					display: inline-block;
 				}
 
@@ -164,7 +164,9 @@ The `userLoggedIn` attribute will control whether the registration/signin callou
 
 		<template is="dom-if" if="{{!userLoggedIn}}">
 			<div class="register-cta">
-				<span><a href="#">Register</a> or <a href="#">Log in</a></span>
+				<span class="long-text">
+					<content select=".register-cta-text"></content>
+				</span>
 				<figure>
 					<a href="{{anonAvatarHref}}">
 						<img src="{{anonAvatarSrc}}" alt="Register or log in">

--- a/gh-pages/vendor/wikia-style-guide/dist/components/user-status/user-status.html
+++ b/gh-pages/vendor/wikia-style-guide/dist/components/user-status/user-status.html
@@ -139,7 +139,7 @@ The `userLoggedIn` attribute will control whether the registration/signin callou
 					width: 150px;
 				}
 
-				.register-cta span {
+				.register-cta .long-text {
 					display: inline-block;
 				}
 
@@ -164,7 +164,9 @@ The `userLoggedIn` attribute will control whether the registration/signin callou
 
 		<template is="dom-if" if="{{!userLoggedIn}}">
 			<div class="register-cta">
-				<span><a href="#">Register</a> or <a href="#">Log in</a></span>
+				<span class="long-text">
+					<content select=".register-cta-text"></content>
+				</span>
 				<figure>
 					<a href="{{anonAvatarHref}}">
 						<img src="{{anonAvatarSrc}}" alt="Register or log in">

--- a/src/components/user-status/user-status.html
+++ b/src/components/user-status/user-status.html
@@ -139,7 +139,7 @@ The `userLoggedIn` attribute will control whether the registration/signin callou
 					width: 150px;
 				}
 
-				.register-cta span {
+				.register-cta .long-text {
 					display: inline-block;
 				}
 
@@ -164,7 +164,9 @@ The `userLoggedIn` attribute will control whether the registration/signin callou
 
 		<template is="dom-if" if="{{!userLoggedIn}}">
 			<div class="register-cta">
-				<span><a href="#">Register</a> or <a href="#">Log in</a></span>
+				<span class="long-text">
+					<content select=".register-cta-text"></content>
+				</span>
 				<figure>
 					<a href="{{anonAvatarHref}}">
 						<img src="{{anonAvatarSrc}}" alt="Register or log in">


### PR DESCRIPTION
Before, the "register" and "Login" text was hard-coded. This gives the app a chance to determine the wording and i18n. 
