### PR TITLE
Add utility classes for hiding on desktop or mobile

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "wikia-style-guide",
-  "version": "1.4.4",
+  "version": "1.4.5",
   "homepage": "http://wikia.github.io/style-guide",
   "authors": [
     "Kenneth Kouot <kenneth@wikia-inc.com>"

--- a/dist/css/lib/components/visibility.css
+++ b/dist/css/lib/components/visibility.css
@@ -396,3 +396,11 @@ th.hide-for-touch {
     display: table-cell !important; }
   th.show-for-print {
     display: table-cell !important; } }
+
+@media only screen and (max-width: 1063px) {
+  .mobile-hidden {
+    display: none; } }
+
+@media only screen and (min-width: 1064px) {
+  .desktop-hidden {
+    display: none; } }

--- a/dist/css/main.css
+++ b/dist/css/main.css
@@ -5569,3 +5569,11 @@ th.hide-for-touch {
     display: table-cell !important; }
   th.show-for-print {
     display: table-cell !important; } }
+
+@media only screen and (max-width: 1063px) {
+  .mobile-hidden {
+    display: none; } }
+
+@media only screen and (min-width: 1064px) {
+  .desktop-hidden {
+    display: none; } }

--- a/gh-pages/vendor/wikia-style-guide/dist/css/lib/components/visibility.css
+++ b/gh-pages/vendor/wikia-style-guide/dist/css/lib/components/visibility.css
@@ -396,3 +396,11 @@ th.hide-for-touch {
     display: table-cell !important; }
   th.show-for-print {
     display: table-cell !important; } }
+
+@media only screen and (max-width: 1063px) {
+  .mobile-hidden {
+    display: none; } }
+
+@media only screen and (min-width: 1064px) {
+  .desktop-hidden {
+    display: none; } }

--- a/gh-pages/vendor/wikia-style-guide/dist/css/main.css
+++ b/gh-pages/vendor/wikia-style-guide/dist/css/main.css
@@ -5569,3 +5569,11 @@ th.hide-for-touch {
     display: table-cell !important; }
   th.show-for-print {
     display: table-cell !important; } }
+
+@media only screen and (max-width: 1063px) {
+  .mobile-hidden {
+    display: none; } }
+
+@media only screen and (min-width: 1064px) {
+  .desktop-hidden {
+    display: none; } }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wikia-style-guide",
-  "version": "1.4.4",
+  "version": "1.4.5",
   "description": "Wikia Style Guide ===========",
   "main": "index.js",
   "scripts": {

--- a/src/scss/lib/components/visibility.scss
+++ b/src/scss/lib/components/visibility.scss
@@ -383,7 +383,6 @@ $visibility-breakpoint-queries:
   th.hide-for-touch { display: table-cell !important; }
   .touch th.show-for-touch { display: table-cell !important; }
 
-
   /* Print visibility */
   @media print {
     .show-for-print { display: block; }
@@ -397,5 +396,16 @@ $visibility-breakpoint-queries:
     th.show-for-print { display: table-cell !important; }
 
   }
+}
 
+@media #{$mobile-range} {
+	.mobile-hidden {
+		display: none;
+	}
+}
+
+@media #{$desktop-range} {
+	.desktop-hidden {
+		display: none;
+	}
 }


### PR DESCRIPTION
This change adds two classes for convenience, which allow hiding content on all desktop breakpoints or all non-desktop (mobile) breakpoints.
