### PR TITLE
Update grid breakpoints and disable nested margins

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "wikia-style-guide",
-  "version": "1.4.4",
+  "version": "1.5.0",
   "homepage": "http://wikia.github.io/style-guide",
   "authors": [
     "Kenneth Kouot <kenneth@wikia-inc.com>"

--- a/dist/css/lib/components/grid.css
+++ b/dist/css/lib/components/grid.css
@@ -120,30 +120,28 @@ select {
     margin-right: 0; }
   .row .row {
     width: auto;
-    margin-left: -0.9375rem;
-    margin-right: -0.9375rem;
-    margin-top: 0;
-    margin-bottom: 0;
+    margin: 0;
     max-width: none; }
     .row .row:before, .row .row:after {
       content: " ";
       display: table; }
     .row .row:after {
       clear: both; }
-    .row .row.collapse {
+    .row .row.nocollapse {
       width: auto;
-      margin: 0;
+      margin-left: -0.9375rem;
+      margin-right: -0.9375rem;
+      margin-top: 0;
+      margin-bottom: 0;
       max-width: none; }
-      .row .row.collapse:before, .row .row.collapse:after {
+      .row .row.nocollapse:before, .row .row.nocollapse:after {
         content: " ";
         display: table; }
-      .row .row.collapse:after {
+      .row .row.nocollapse:after {
         clear: both; }
 
 .column,
 .columns {
-  padding-left: 0.9375rem;
-  padding-right: 0.9375rem;
   width: 100%;
   float: left; }
 
@@ -253,8 +251,6 @@ select {
   .column,
   .columns {
     position: relative;
-    padding-left: 0.9375rem;
-    padding-right: 0.9375rem;
     float: left; }
   .small-1 {
     width: 8.33333%; }
@@ -330,7 +326,7 @@ select {
   .columns.small-uncentered.opposite {
     float: right; } }
 
-@media only screen and (min-width: 321px) {
+@media only screen and (min-width: 768px) {
   .medium-push-0 {
     position: relative;
     left: 0%;
@@ -430,8 +426,6 @@ select {
   .column,
   .columns {
     position: relative;
-    padding-left: 0.9375rem;
-    padding-right: 0.9375rem;
     float: left; }
   .medium-1 {
     width: 8.33333%; }
@@ -603,7 +597,7 @@ select {
     right: 91.66667%;
     left: auto; } }
 
-@media only screen and (min-width: 768px) {
+@media only screen and (min-width: 1064px) {
   .large-push-0 {
     position: relative;
     left: 0%;
@@ -703,8 +697,6 @@ select {
   .column,
   .columns {
     position: relative;
-    padding-left: 0.9375rem;
-    padding-right: 0.9375rem;
     float: left; }
   .large-1 {
     width: 8.33333%; }

--- a/dist/css/main.css
+++ b/dist/css/main.css
@@ -474,30 +474,28 @@ select {
     margin-right: 0; }
   .row .row {
     width: auto;
-    margin-left: -0.9375rem;
-    margin-right: -0.9375rem;
-    margin-top: 0;
-    margin-bottom: 0;
+    margin: 0;
     max-width: none; }
     .row .row:before, .row .row:after {
       content: " ";
       display: table; }
     .row .row:after {
       clear: both; }
-    .row .row.collapse {
+    .row .row.nocollapse {
       width: auto;
-      margin: 0;
+      margin-left: -0.9375rem;
+      margin-right: -0.9375rem;
+      margin-top: 0;
+      margin-bottom: 0;
       max-width: none; }
-      .row .row.collapse:before, .row .row.collapse:after {
+      .row .row.nocollapse:before, .row .row.nocollapse:after {
         content: " ";
         display: table; }
-      .row .row.collapse:after {
+      .row .row.nocollapse:after {
         clear: both; }
 
 .column,
 .columns {
-  padding-left: 0.9375rem;
-  padding-right: 0.9375rem;
   width: 100%;
   float: left; }
 
@@ -607,8 +605,6 @@ select {
   .column,
   .columns {
     position: relative;
-    padding-left: 0.9375rem;
-    padding-right: 0.9375rem;
     float: left; }
   .small-1 {
     width: 8.33333%; }
@@ -684,7 +680,7 @@ select {
   .columns.small-uncentered.opposite {
     float: right; } }
 
-@media only screen and (min-width: 321px) {
+@media only screen and (min-width: 768px) {
   .medium-push-0 {
     position: relative;
     left: 0%;
@@ -784,8 +780,6 @@ select {
   .column,
   .columns {
     position: relative;
-    padding-left: 0.9375rem;
-    padding-right: 0.9375rem;
     float: left; }
   .medium-1 {
     width: 8.33333%; }
@@ -957,7 +951,7 @@ select {
     right: 91.66667%;
     left: auto; } }
 
-@media only screen and (min-width: 768px) {
+@media only screen and (min-width: 1064px) {
   .large-push-0 {
     position: relative;
     left: 0%;
@@ -1057,8 +1051,6 @@ select {
   .column,
   .columns {
     position: relative;
-    padding-left: 0.9375rem;
-    padding-right: 0.9375rem;
     float: left; }
   .large-1 {
     width: 8.33333%; }

--- a/gh-pages/vendor/wikia-style-guide/dist/css/lib/components/grid.css
+++ b/gh-pages/vendor/wikia-style-guide/dist/css/lib/components/grid.css
@@ -120,30 +120,28 @@ select {
     margin-right: 0; }
   .row .row {
     width: auto;
-    margin-left: -0.9375rem;
-    margin-right: -0.9375rem;
-    margin-top: 0;
-    margin-bottom: 0;
+    margin: 0;
     max-width: none; }
     .row .row:before, .row .row:after {
       content: " ";
       display: table; }
     .row .row:after {
       clear: both; }
-    .row .row.collapse {
+    .row .row.nocollapse {
       width: auto;
-      margin: 0;
+      margin-left: -0.9375rem;
+      margin-right: -0.9375rem;
+      margin-top: 0;
+      margin-bottom: 0;
       max-width: none; }
-      .row .row.collapse:before, .row .row.collapse:after {
+      .row .row.nocollapse:before, .row .row.nocollapse:after {
         content: " ";
         display: table; }
-      .row .row.collapse:after {
+      .row .row.nocollapse:after {
         clear: both; }
 
 .column,
 .columns {
-  padding-left: 0.9375rem;
-  padding-right: 0.9375rem;
   width: 100%;
   float: left; }
 
@@ -253,8 +251,6 @@ select {
   .column,
   .columns {
     position: relative;
-    padding-left: 0.9375rem;
-    padding-right: 0.9375rem;
     float: left; }
   .small-1 {
     width: 8.33333%; }
@@ -330,7 +326,7 @@ select {
   .columns.small-uncentered.opposite {
     float: right; } }
 
-@media only screen and (min-width: 321px) {
+@media only screen and (min-width: 768px) {
   .medium-push-0 {
     position: relative;
     left: 0%;
@@ -430,8 +426,6 @@ select {
   .column,
   .columns {
     position: relative;
-    padding-left: 0.9375rem;
-    padding-right: 0.9375rem;
     float: left; }
   .medium-1 {
     width: 8.33333%; }
@@ -603,7 +597,7 @@ select {
     right: 91.66667%;
     left: auto; } }
 
-@media only screen and (min-width: 768px) {
+@media only screen and (min-width: 1064px) {
   .large-push-0 {
     position: relative;
     left: 0%;
@@ -703,8 +697,6 @@ select {
   .column,
   .columns {
     position: relative;
-    padding-left: 0.9375rem;
-    padding-right: 0.9375rem;
     float: left; }
   .large-1 {
     width: 8.33333%; }

--- a/gh-pages/vendor/wikia-style-guide/dist/css/main.css
+++ b/gh-pages/vendor/wikia-style-guide/dist/css/main.css
@@ -474,30 +474,28 @@ select {
     margin-right: 0; }
   .row .row {
     width: auto;
-    margin-left: -0.9375rem;
-    margin-right: -0.9375rem;
-    margin-top: 0;
-    margin-bottom: 0;
+    margin: 0;
     max-width: none; }
     .row .row:before, .row .row:after {
       content: " ";
       display: table; }
     .row .row:after {
       clear: both; }
-    .row .row.collapse {
+    .row .row.nocollapse {
       width: auto;
-      margin: 0;
+      margin-left: -0.9375rem;
+      margin-right: -0.9375rem;
+      margin-top: 0;
+      margin-bottom: 0;
       max-width: none; }
-      .row .row.collapse:before, .row .row.collapse:after {
+      .row .row.nocollapse:before, .row .row.nocollapse:after {
         content: " ";
         display: table; }
-      .row .row.collapse:after {
+      .row .row.nocollapse:after {
         clear: both; }
 
 .column,
 .columns {
-  padding-left: 0.9375rem;
-  padding-right: 0.9375rem;
   width: 100%;
   float: left; }
 
@@ -607,8 +605,6 @@ select {
   .column,
   .columns {
     position: relative;
-    padding-left: 0.9375rem;
-    padding-right: 0.9375rem;
     float: left; }
   .small-1 {
     width: 8.33333%; }
@@ -684,7 +680,7 @@ select {
   .columns.small-uncentered.opposite {
     float: right; } }
 
-@media only screen and (min-width: 321px) {
+@media only screen and (min-width: 768px) {
   .medium-push-0 {
     position: relative;
     left: 0%;
@@ -784,8 +780,6 @@ select {
   .column,
   .columns {
     position: relative;
-    padding-left: 0.9375rem;
-    padding-right: 0.9375rem;
     float: left; }
   .medium-1 {
     width: 8.33333%; }
@@ -957,7 +951,7 @@ select {
     right: 91.66667%;
     left: auto; } }
 
-@media only screen and (min-width: 768px) {
+@media only screen and (min-width: 1064px) {
   .large-push-0 {
     position: relative;
     left: 0%;
@@ -1057,8 +1051,6 @@ select {
   .column,
   .columns {
     position: relative;
-    padding-left: 0.9375rem;
-    padding-right: 0.9375rem;
     float: left; }
   .large-1 {
     width: 8.33333%; }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wikia-style-guide",
-  "version": "1.4.4",
+  "version": "1.5.0",
   "description": "Wikia Style Guide ===========",
   "main": "index.js",
   "scripts": {

--- a/src/scss/lib/components/grid.scss
+++ b/src/scss/lib/components/grid.scss
@@ -87,7 +87,7 @@
   $offset:false,
   $push:false,
   $pull:false,
-  $collapse:false,
+  $collapse:null,
   $float:true,
   $position:false) {
 
@@ -215,8 +215,8 @@
         .row {margin-left:0; margin-right:0;}
       }
 
-      .row { @include grid-row($behavior:nest);
-        &.collapse { @include grid-row($behavior:nest-collapse); }
+      .row { @include grid-row($behavior:nest-collapse);
+        &.nocollapse { @include grid-row($behavior:nest); }
       }
     }
 
@@ -226,11 +226,11 @@
     [class*="column"] + [class*="column"]:last-child { float: $last-child-float; }
     [class*="column"] + [class*="column"].end { float: $default-float; }
 
-    @media #{$small-up} {
+    @media #{$small-up} { // Mobile
       @include grid-html-classes($size:small);
     }
 
-    @media #{$medium-up} {
+    @media #{$large-up} { // Tablet
       @include grid-html-classes($size:medium);
       // Old push and pull classes
       @for $i from 0 through $total-columns - 1 {
@@ -242,7 +242,7 @@
         }
       }
     }
-    @media #{$large-up} {
+    @media #{$xlarge-up} { // Desktop
       @include grid-html-classes($size:large);
       @for $i from 0 through $total-columns - 1 {
         .push-#{$i} {


### PR DESCRIPTION
These changes update the grid breakpoints so that we can actually start using it in Mercury. This also reverses Foundation's "nest" and "nest-collapse" behavior for grid rows, because nest-collapse is more intuitive for grids inside containers with padding.
