### PR TITLE
Layout | Removing 18px font base on large screens, as it is not working anyway

### DIFF
--- a/dist/css/lib/components/dropdown.css
+++ b/dist/css/lib/components/dropdown.css
@@ -317,11 +317,6 @@ body {
   color: #39424D;
   font-size: 16px; }
 
-@media only screen and (min-width: 1064px) {
-  html,
-  body {
-    font-size: 18px; } }
-
 /* Typography resets */
 div,
 dl,

--- a/dist/css/lib/components/type.css
+++ b/dist/css/lib/components/type.css
@@ -216,11 +216,6 @@ body {
   color: #39424D;
   font-size: 16px; }
 
-@media only screen and (min-width: 1064px) {
-  html,
-  body {
-    font-size: 18px; } }
-
 /* Typography resets */
 div,
 dl,

--- a/dist/css/main.css
+++ b/dist/css/main.css
@@ -1849,11 +1849,6 @@ body {
   color: #39424D;
   font-size: 16px; }
 
-@media only screen and (min-width: 1064px) {
-  html,
-  body {
-    font-size: 18px; } }
-
 /* Typography resets */
 div,
 dl,
@@ -4637,11 +4632,6 @@ html,
 body {
   color: #39424D;
   font-size: 16px; }
-
-@media only screen and (min-width: 1064px) {
-  html,
-  body {
-    font-size: 18px; } }
 
 /* Typography resets */
 div,

--- a/gh-pages/vendor/wikia-style-guide/dist/css/lib/components/dropdown.css
+++ b/gh-pages/vendor/wikia-style-guide/dist/css/lib/components/dropdown.css
@@ -317,11 +317,6 @@ body {
   color: #39424D;
   font-size: 16px; }
 
-@media only screen and (min-width: 1064px) {
-  html,
-  body {
-    font-size: 18px; } }
-
 /* Typography resets */
 div,
 dl,

--- a/gh-pages/vendor/wikia-style-guide/dist/css/lib/components/type.css
+++ b/gh-pages/vendor/wikia-style-guide/dist/css/lib/components/type.css
@@ -216,11 +216,6 @@ body {
   color: #39424D;
   font-size: 16px; }
 
-@media only screen and (min-width: 1064px) {
-  html,
-  body {
-    font-size: 18px; } }
-
 /* Typography resets */
 div,
 dl,

--- a/gh-pages/vendor/wikia-style-guide/dist/css/main.css
+++ b/gh-pages/vendor/wikia-style-guide/dist/css/main.css
@@ -1849,11 +1849,6 @@ body {
   color: #39424D;
   font-size: 16px; }
 
-@media only screen and (min-width: 1064px) {
-  html,
-  body {
-    font-size: 18px; } }
-
 /* Typography resets */
 div,
 dl,
@@ -4637,11 +4632,6 @@ html,
 body {
   color: #39424D;
   font-size: 16px; }
-
-@media only screen and (min-width: 1064px) {
-  html,
-  body {
-    font-size: 18px; } }
 
 /* Typography resets */
 div,

--- a/src/scss/lib/components/type.scss
+++ b/src/scss/lib/components/type.scss
@@ -77,14 +77,6 @@ $align-class-breakpoints:
         font-size: $base-font-size;
     }
 
-    // Larger screens receive larger base font size
-    @media #{$xlarge-up} {
-        html,
-        body {
-            font-size: $base-font-size + 2;
-        }
-    }
-
     /* Typography resets */
     div,
     dl,


### PR DESCRIPTION
DO NOT MERGE UNTIL TESTED.

@vforge @hakubo @bognix @mklucsarits 

This thing wasn't working anyway. In the browsers there was still 16px set as a base-font for html/body (it overrides 18px). 

Discussed with UX, they're fine with having one, consistent base font everywhere which was also my dream since I was 12 years old.

Cheers!
