### PR TITLE
Move gulp to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "homepage": "https://github.com/Wikia/style-guide",
   "devDependencies": {
     "del": "^1.1.1",
+    "gulp": "^3.8.10",
     "gulp-if": "^1.2.5",
     "gulp-minify-html": "^1.0.4",
     "gulp-minify-inline": "^0.1.1",
@@ -31,8 +32,5 @@
     "gulp-uglify": "^1.2.0",
     "node-sass": "^3.2.0",
     "vulcanize": "^1.10.3"
-  },
-  "dependencies": {
-    "gulp": "^3.8.10"
   }
 }


### PR DESCRIPTION
I want to install the style guide using npm but I don't want gulp.

@kvas-damian 