### PR TITLE
Make $include-print-styles overridable

### DIFF
--- a/src/scss/lib/_settings.scss
+++ b/src/scss/lib/_settings.scss
@@ -47,7 +47,7 @@ $base-line-height: 150%;
 
 // We use this to control whether or not CSS classes come through in the gem files.
 $include-html-classes: true;
-$include-print-styles: true;
+$include-print-styles: true !default;
 $include-html-global-classes: $include-html-classes;
 
 // b. Grid


### PR DESCRIPTION
`@print` isn't supported by AMP, so let's make it configurable if an app gets the print styles. I've confirmed that the built CSS is exactly the same.